### PR TITLE
Fix textTrack eventlistener removal

### DIFF
--- a/ios/THEOplayerRCTView.swift
+++ b/ios/THEOplayerRCTView.swift
@@ -33,6 +33,7 @@ class THEOplayerRCTView: UIView {
     }
     
     deinit {
+        self.eventHandler.destroy()
         self.player?.destroy()
         self.player = nil
     }

--- a/ios/THEOplayerRCTViewEventHandler.swift
+++ b/ios/THEOplayerRCTViewEventHandler.swift
@@ -64,9 +64,9 @@ class THEOplayerRCTViewEventHandler {
     private var removeCueListeners: [Int:EventListener] = [:]
     
     
-    // MARK: - Initialisation / deinitialisation
-    deinit {
-        // detach listeners
+    // MARK: - destruction
+    func destroy() {
+        // dettach listeners
         self.dettachListeners()
     }
     


### PR DESCRIPTION
Destroying the eventHandler (which triggers eventListener removal) before the player is destructed. Otherwise the player is in a ;destructed' state and player.textTrackList is not accessible.