### PR TITLE
Disable all debug logs for release

### DIFF
--- a/ios/THEOplayerRCTDebug.swift
+++ b/ios/THEOplayerRCTDebug.swift
@@ -1,7 +1,7 @@
 // THEOplayerRCTDebug.swift
 
 // General debug flag, if set to false none of the debug prints will appear
-let DEBUG = true
+let DEBUG = false
 
 // Debug flag to monitor incoming Theoplayer events
 let DEBUG_THEOPLAYER_EVENTS = DEBUG && true


### PR DESCRIPTION
When releasing v1.4.0 we forgot to disable the debug logs on the iOS bridge. To fix this we changed DEBUG back to false to block all debug logs