### PR TITLE
Exclude folders from bob build

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,5 +1,5 @@
 
 {
   "extends": "./tsconfig",
-  "exclude": ["example"]
+  "exclude": ["example", "ios", "android"]
 }


### PR DESCRIPTION
When running `bob build`, creating the typescript definition file failed when a custom iOS framework was being used because bob build was also considering any js files in the framework.
Any of these files should be excluded.