### PR TITLE
Set fullscreen explicitly to false during cleanup

### DIFF
--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerView.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerView.kt
@@ -245,6 +245,7 @@ class ReactTHEOplayerView(private val reactContext: ThemedReactContext) :
     if (BuildConfig.LOG_VIEW_EVENTS) {
       Log.d(TAG, "cleanUpResources")
     }
+    setFullscreen(false)
     releasePlayer()
   }
 


### PR DESCRIPTION
When the player is used like `<THEOplayerView fullscreen={true} />` in combination with an [edge-to-edge system UI](https://developer.android.com/develop/ui/views/layout/edge-to-edge), the system UI is not restored if the component is unmounted and the prop was never explicitly set/changed to `false`.

To combat this, the player should explicitly turn fullscreen off again when it is cleaning up after itself. We have this as a local patch in our repository, I'm not sure if this is also an actual bug upstream and/or if it needs more refinement.