### PR TITLE
Limit pause event filtering during ads

### DIFF
--- a/android/src/main/java/com/theoplayer/PlayerEventEmitter.kt
+++ b/android/src/main/java/com/theoplayer/PlayerEventEmitter.kt
@@ -322,9 +322,9 @@ class PlayerEventEmitter internal constructor(
   }
 
   private fun onPause() {
-    val player = playerView.player
+    val player = playerView.player ?: return
     // Do not forward the pause event in case the content player is paused because the ad player starts.
-    if (player != null && !(playerView.adsApi.isPlaying && !player.isPaused)) {
+    if (!playerView.adsApi.isPlaying || player.isPaused) {
       receiveEvent(EVENT_PAUSE, null)
     }
   }


### PR DESCRIPTION
The THEOplayer Unified Android SDK fires a pause event when switching from the content player to the ad player (using CSAI). The React Native SDK dealt with this by not forwarding pause events when `player.ads.isPlaying == true`. The downside of this approach that no pause events come through at all (for both CSAI and SSAI) when the user pauses the player during an ad. 

This small PR suggests a change to only filter out the pause event on the context switch from content player to ad player. In that pause event `player.ads.isPlaying == true` and `player.isPaused == false`. On any regular pause event, `player.isPaused == true`.