### PR TITLE
[Android] Chore: Fix deprecated code and unchecked cast warnings

### DIFF
--- a/android/src/main/java/com/theoplayer/player/PlayerModule.kt
+++ b/android/src/main/java/com/theoplayer/player/PlayerModule.kt
@@ -6,7 +6,6 @@ import com.theoplayer.abr.ABRConfigurationAdapter
 import com.theoplayer.android.api.player.PreloadType
 import com.theoplayer.android.api.player.PresentationMode
 import com.theoplayer.android.api.player.track.mediatrack.MediaTrack
-import com.theoplayer.android.api.player.track.mediatrack.quality.VideoQuality
 import com.theoplayer.android.api.player.track.texttrack.TextTrackMode
 import com.theoplayer.track.QualityListFilter
 import com.theoplayer.track.emptyQualityList
@@ -119,7 +118,7 @@ class PlayerModule(context: ReactApplicationContext) : ReactContextBaseJavaModul
   fun setTargetVideoQuality(tag: Int, uids: ReadableArray) {
     viewResolver.resolveViewByTag(tag) { view: ReactTHEOplayerView? ->
       view?.selectedVideoTrack?.let {
-        val currentVideoTrack = it as MediaTrack<VideoQuality>
+        val currentVideoTrack = it as MediaTrack<*>
         if (uids.size() == 0) {
           // Reset target qualities when passing empty list.
           currentVideoTrack.targetQualities = emptyQualityList()

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -15,7 +15,8 @@ import android.view.SurfaceView
 import android.view.TextureView
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 import com.facebook.react.uimanager.ThemedReactContext
 import com.theoplayer.PlayerEventEmitter
 import com.theoplayer.android.api.THEOplayerView
@@ -160,22 +161,14 @@ class PresentationManager(
     this.fullscreen = fullscreen
     val activity = reactContext.currentActivity ?: return
     val window = activity.window
-    val decorView = window.decorView
-    val uiOptions: Int
     if (fullscreen) {
-      uiOptions = if (Build.VERSION.SDK_INT >= 19) { // 4.4+
-        (FrameLayout.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-          or FrameLayout.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-          or FrameLayout.SYSTEM_UI_FLAG_FULLSCREEN)
-      } else {
-        (FrameLayout.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-          or FrameLayout.SYSTEM_UI_FLAG_FULLSCREEN)
-      }
-      decorView.systemUiVisibility = uiOptions
+      WindowInsetsControllerCompat(window, window.decorView).apply {
+        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+      }.hide(WindowInsetsCompat.Type.systemBars())
       eventEmitter.emitPresentationModeChange(PresentationMode.FULLSCREEN)
     } else {
-      uiOptions = FrameLayout.SYSTEM_UI_FLAG_VISIBLE
-      decorView.systemUiVisibility = uiOptions
+      WindowInsetsControllerCompat(window, window.decorView).show(
+        WindowInsetsCompat.Type.systemBars())
       eventEmitter.emitPresentationModeChange(PresentationMode.INLINE)
     }
   }


### PR DESCRIPTION
1. Update deprecated code related to setting of `decorView.systemUiVisibility` to deprecated flags in PresentationManager.kt.
2. Fix minor type warning in PlayerModule.kt.
3. Update imports in changed files.

**Test-plan:**

1. Run test application
2. Feed player with any test VOD
3. Smoke test between presentation modes
4. Expected: It hides system UI/bars on fullscreen and shows system UI on move back to inline