### PR TITLE
Remove Promises from CastAPI

### DIFF
--- a/src/api/cast/Airplay.ts
+++ b/src/api/cast/Airplay.ts
@@ -3,18 +3,18 @@
  *
  * @public
  */
-import type {CastState} from "./CastState";
+import type { CastState } from './CastState';
 
 export interface Airplay {
   /**
    * Whether the player is connected with an airplay device.
    */
-  casting(): Promise<boolean>;
+  readonly casting: boolean;
 
   /**
    * The state of the casting process.
    */
-  state(): Promise<CastState>;
+  readonly state: CastState;
 
   /**
    * Start a casting session with the player's source.

--- a/src/api/cast/CastAPI.ts
+++ b/src/api/cast/CastAPI.ts
@@ -1,16 +1,15 @@
-import type {Airplay} from "./Airplay";
-import type {Chromecast} from "./Chromecast";
+import type { Airplay } from './Airplay';
+import type { Chromecast } from './Chromecast';
 
 /**
  * The API for casting.
  */
 
-
 export interface CastAPI {
   /**
    * Whether the player is connected with a casting device.
    */
-  casting(): Promise<boolean>;
+  readonly casting: boolean;
 
   /**
    * The Chromecast API.

--- a/src/api/cast/Chromecast.ts
+++ b/src/api/cast/Chromecast.ts
@@ -3,18 +3,18 @@
  *
  * @public
  */
-import type {CastState} from "./CastState";
+import type { CastState } from './CastState';
 
 export interface Chromecast {
   /**
    * Whether the player is connected with a chromecast device.
    */
-  casting(): Promise<boolean>;
+  readonly casting: boolean;
 
   /**
    * The state of the casting process.
    */
-  state(): Promise<CastState>;
+  readonly state: CastState;
 
   /**
    * Start a casting session with the player's source.

--- a/src/internal/adapter/THEOplayerAdapter.ts
+++ b/src/internal/adapter/THEOplayerAdapter.ts
@@ -80,7 +80,7 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
     this._view = view;
     this._state = { ...initialState };
     this._adsAdapter = new THEOplayerNativeAdsAdapter(this._view);
-    this._castAdapter = new THEOplayerNativeCastAdapter(this._view);
+    this._castAdapter = new THEOplayerNativeCastAdapter(this, this._view);
     this._abrAdapter = new AbrAdapter(this._view);
     this._textTrackStyleAdapter = new TextTrackStyleAdapter(this._view);
 

--- a/src/internal/adapter/cast/THEOplayerNativeCastAdapter.ts
+++ b/src/internal/adapter/cast/THEOplayerNativeCastAdapter.ts
@@ -1,21 +1,22 @@
-import { NativeModules, Platform } from 'react-native';
+import { Platform } from 'react-native';
 import { THEOplayerNativeChromecast } from './THEOplayerNativeChromecast';
 import { THEOplayerNativeAirplay } from './THEOplayerNativeAirplay';
 import type { Airplay, CastAPI, Chromecast, THEOplayerView } from 'react-native-theoplayer';
+import type { THEOplayer } from 'react-native-theoplayer';
 
 export class THEOplayerNativeCastAdapter implements CastAPI {
-  private readonly _chromecast: Chromecast;
-  private readonly _airplay: Airplay | undefined;
+  private readonly _chromecast: THEOplayerNativeChromecast;
+  private readonly _airplay: THEOplayerNativeAirplay | undefined;
 
-  constructor(private readonly _player: THEOplayerView) {
-    this._chromecast = new THEOplayerNativeChromecast(this._player);
+  constructor(private readonly _player: THEOplayer, private readonly _view: THEOplayerView) {
+    this._chromecast = new THEOplayerNativeChromecast(this._player, this._view);
     if (Platform.OS !== 'android') {
       this._airplay = new THEOplayerNativeAirplay(this._player);
     }
   }
 
-  casting(): Promise<boolean> {
-    return NativeModules.CastModule.casting(this._player.nativeHandle);
+  get casting(): boolean {
+    return this._chromecast.casting || this._airplay?.casting === true;
   }
 
   get chromecast(): Chromecast | undefined {
@@ -24,5 +25,10 @@ export class THEOplayerNativeCastAdapter implements CastAPI {
 
   get airplay(): Airplay | undefined {
     return this._airplay;
+  }
+
+  unload_(): void {
+    this._chromecast.unload_();
+    this._airplay?.unload_();
   }
 }

--- a/src/internal/adapter/cast/THEOplayerNativeChromecast.ts
+++ b/src/internal/adapter/cast/THEOplayerNativeChromecast.ts
@@ -1,30 +1,58 @@
-import type { CastState, Chromecast, THEOplayerView } from 'react-native-theoplayer';
+import type { CastEvent, CastState, Chromecast, THEOplayerView } from 'react-native-theoplayer';
+import { CastEventType, PlayerEventType, THEOplayer } from 'react-native-theoplayer';
 import { NativeModules } from 'react-native';
 
 export class THEOplayerNativeChromecast implements Chromecast {
-  public constructor(private readonly _player: THEOplayerView) {}
+  private readonly _player: THEOplayer;
+  private readonly _view: THEOplayerView;
 
-  casting(): Promise<boolean> {
-    return NativeModules.CastModule.chromecastCasting(this._player.nativeHandle);
+  private _casting = false;
+  private _state: CastState = 'available';
+
+  public constructor(player: THEOplayer, view: THEOplayerView) {
+    this._player = player;
+    this._view = view;
+    this._player.addEventListener(PlayerEventType.CAST_EVENT, this._onCastStateChange);
+    void this.init_();
   }
 
-  state(): Promise<CastState> {
-    return NativeModules.CastModule.chromecastState(this._player.nativeHandle);
+  async init_(): Promise<void> {
+    this._casting = await NativeModules.CastModule.chromecastCasting(this._view.nativeHandle);
+    this._state = await NativeModules.CastModule.chromecastState(this._view.nativeHandle);
+  }
+
+  private readonly _onCastStateChange = (event: CastEvent) => {
+    if (event.subType === CastEventType.CHROMECAST_STATE_CHANGE) {
+      this._state = event.state;
+      this._casting = event.state === 'connected';
+    }
+  };
+
+  get casting(): boolean {
+    return this._casting;
+  }
+
+  get state(): CastState {
+    return this._state;
   }
 
   start(): void {
-    NativeModules.CastModule.chromecastStart(this._player.nativeHandle);
+    NativeModules.CastModule.chromecastStart(this._view.nativeHandle);
   }
 
   stop(): void {
-    NativeModules.CastModule.chromecastStop(this._player.nativeHandle);
+    NativeModules.CastModule.chromecastStop(this._view.nativeHandle);
   }
 
   join(): void {
-    NativeModules.CastModule.chromecastJoin(this._player.nativeHandle);
+    NativeModules.CastModule.chromecastJoin(this._view.nativeHandle);
   }
 
   leave(): void {
-    NativeModules.CastModule.chromecastLeave(this._player.nativeHandle);
+    NativeModules.CastModule.chromecastLeave(this._view.nativeHandle);
+  }
+
+  unload_(): void {
+    this._player.removeEventListener(PlayerEventType.CAST_EVENT, this._onCastStateChange);
   }
 }

--- a/src/internal/adapter/cast/THEOplayerWebCastAdapter.ts
+++ b/src/internal/adapter/cast/THEOplayerWebCastAdapter.ts
@@ -9,8 +9,8 @@ export class THEOplayerWebCastAdapter implements CastAPI {
     this._player = player;
   }
 
-  casting(): Promise<boolean> {
-    return Promise.resolve(false);
+  get casting(): boolean {
+    return false;
   }
 
   get chromecast(): Chromecast | undefined {


### PR DESCRIPTION
This PR removes Promises from the `CastAPI`, and relies instead on tracking the state using an event listener on `THEOplayer`.