### PR TITLE
Feature/mediasession web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue on iOS Safari where switching to fullscreen presentation during an ad would not work.
 - Fixed an issue on iOS Safari where an ad could be skipped during unmuted autoplay.
 
+### Changed
+
+- Changed Web media session controls to only show trick-play buttons if the player is in foreground, or `backgroundAudioEnabled` is `true`, and never for ads and live stream.
+- Changed Web media session controls to only show a play/pause button if the player is in foreground, or `backgroundAudioEnabled` is `true`, and never for ads.
+
 ## [2.3.0] - 23-04-14
 
 ### Changed

--- a/src/internal/adapter/THEOplayerAdapter.ts
+++ b/src/internal/adapter/THEOplayerAdapter.ts
@@ -372,7 +372,7 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   set selectedTextTrack(trackUid: number | undefined) {
     this._state.selectedTextTrack = trackUid;
     this.textTracks.forEach((track) => {
-      if (track.uid == trackUid) {
+      if (track.uid === trackUid) {
         track.mode = TextTrackMode.showing;
       } else if (track.mode === TextTrackMode.showing) {
         track.mode = TextTrackMode.disabled;

--- a/src/internal/adapter/web/WebMediaSession.ts
+++ b/src/internal/adapter/web/WebMediaSession.ts
@@ -158,10 +158,16 @@ export class WebMediaSession {
     return document.visibilityState !== 'visible';
   }
 
+  // By default, only show trick-play buttons if:
+  // - backgroundAudio is enabled, or the player is in foreground;
+  // - and, the current asset is neither a live stream, nor an ad.
   private isTrickplayEnabled(): boolean {
     return (this.isBackgroundAudioEnabled() || !this.isInBackground()) && !this.isLive() && !this.isInAd();
   }
 
+  // By default, only show a play/pause button if:
+  // - backgroundAudio is enabled, or the player is in foreground;
+  // - and, the current asset is not an ad.
   private isPlayPauseEnabled(): boolean {
     return (this.isBackgroundAudioEnabled() || !this.isInBackground()) && !this.isInAd();
   }

--- a/src/internal/adapter/web/WebMediaSession.ts
+++ b/src/internal/adapter/web/WebMediaSession.ts
@@ -1,7 +1,6 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import type { ChromelessPlayer } from 'theoplayer';
 import type { THEOplayerWebAdapter } from '../THEOplayerWebAdapter';
-import { PresentationMode } from 'react-native-theoplayer';
 
 interface WebMediaSessionConfig {
   skipTime: number;
@@ -151,7 +150,7 @@ export class WebMediaSession {
     return !isFinite(this._player.duration);
   }
 
-  private isAd(): boolean {
+  private inAd(): boolean {
     return this._player.ads?.playing == true;
   }
 
@@ -160,34 +159,14 @@ export class WebMediaSession {
   }
 
   private isTrickplayEnabled(): boolean {
-    // By default, no trickplay for live
-    if (this.isLive()) {
-      return false;
-    }
-
-    // In PiP mode, disable trick-play for ads.
-    if (this._webAdapter.presentationMode === PresentationMode.pip) {
-      return !this.isAd();
-    }
-    // During background playback
-    if (this.isInBackground()) {
-      // Disable trick-play for ads.
-      return !(this.isAd() || this.isLive());
-    }
-    return true;
+    return (this.isBackgroundAudioEnabled() || !this.isInBackground()) && !this.isLive() && !this.inAd();
   }
 
   private isPlayPauseEnabled(): boolean {
-    // In PiP mode
-    if (this._webAdapter.presentationMode === PresentationMode.pip) {
-      // Disable play/pause for ads
-      return !this.isAd();
-    }
-    // During background playback
-    if (this.isInBackground()) {
-      // Disable play/pause for ads & live content.
-      return !(this.isAd() || this.isLive());
-    }
-    return true;
+    return (this.isBackgroundAudioEnabled() || !this.isInBackground()) && !this.inAd();
+  }
+
+  private isBackgroundAudioEnabled(): boolean {
+    return this._webAdapter.backgroundAudioConfiguration.enabled == true;
   }
 }

--- a/src/internal/adapter/web/WebMediaSession.ts
+++ b/src/internal/adapter/web/WebMediaSession.ts
@@ -151,7 +151,7 @@ export class WebMediaSession {
   }
 
   private isInAd(): boolean {
-    return this._player.ads?.playing == true;
+    return this._player.ads?.playing === true;
   }
 
   private isInBackground(): boolean {
@@ -173,6 +173,6 @@ export class WebMediaSession {
   }
 
   private isBackgroundAudioEnabled(): boolean {
-    return this._webAdapter.backgroundAudioConfiguration.enabled == true;
+    return this._webAdapter.backgroundAudioConfiguration.enabled === true;
   }
 }

--- a/src/internal/adapter/web/WebMediaSession.ts
+++ b/src/internal/adapter/web/WebMediaSession.ts
@@ -150,7 +150,7 @@ export class WebMediaSession {
     return !isFinite(this._player.duration);
   }
 
-  private inAd(): boolean {
+  private isInAd(): boolean {
     return this._player.ads?.playing == true;
   }
 
@@ -159,11 +159,11 @@ export class WebMediaSession {
   }
 
   private isTrickplayEnabled(): boolean {
-    return (this.isBackgroundAudioEnabled() || !this.isInBackground()) && !this.isLive() && !this.inAd();
+    return (this.isBackgroundAudioEnabled() || !this.isInBackground()) && !this.isLive() && !this.isInAd();
   }
 
   private isPlayPauseEnabled(): boolean {
-    return (this.isBackgroundAudioEnabled() || !this.isInBackground()) && !this.inAd();
+    return (this.isBackgroundAudioEnabled() || !this.isInBackground()) && !this.isInAd();
   }
 
   private isBackgroundAudioEnabled(): boolean {

--- a/src/internal/adapter/web/WebPresentationModeManager.ts
+++ b/src/internal/adapter/web/WebPresentationModeManager.ts
@@ -63,7 +63,7 @@ export class WebPresentationModeManager {
       }
     }
     // listen for pip updates on element
-    if (this._element != null) {
+    if (this._element !== undefined) {
       this._element.onenterpictureinpicture = () => {
         this.updatePresentationMode();
       };


### PR DESCRIPTION
Update web media session rules:

By default, only show trick-play buttons if:
- backgroundAudio is enabled, or the player is in foreground;
- and, the current asset is neither a live stream, nor an ad.

By default, only show a play/pause button if:
- backgroundAudio is enabled, or the player is in foreground;
- and, the current asset is not an ad.

Later on we need to make the rules configurable.