### PR TITLE
Bugfix/safe api after destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## Fixed
+### Fixed
 
 - Fixed an issue on Android where the order of text and media tracks would change when adding tracks.
+- Fixed an issue on Web where an exception would be thrown when accessing the player API after the player had been destroyed.
 
 ## [2.5.0] - 23-04-26
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -16,7 +16,6 @@
         "react-native-svg": "^13.8.0",
         "react-native-web": "^0.19.2",
         "react-native-web-image-loader": "^0.1.1",
-        "theoplayer": "^5.0.0",
         "ts-loader": "^8.2.0",
         "url-polyfill": "^1.1.12"
       },
@@ -16988,11 +16987,6 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
-    },
-    "node_modules/theoplayer": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-5.0.2.tgz",
-      "integrity": "sha512-O5GrtCo/61axddFjteQHTqfdnEOrTruS5Y9hTl6IVNkiA7hORtPN266VqBaROHoOhv/NWKfY/vTZ0KAyPDefXA=="
     },
     "node_modules/throat": {
       "version": "5.0.0",

--- a/src/internal/THEOplayerView.web.tsx
+++ b/src/internal/THEOplayerView.web.tsx
@@ -2,8 +2,6 @@ import React, { useEffect, useRef } from 'react';
 import type { THEOplayerViewProps } from 'react-native-theoplayer';
 import * as THEOplayer from 'theoplayer';
 import { THEOplayerWebAdapter } from './adapter/THEOplayerWebAdapter';
-import { BaseEvent } from './adapter/event/BaseEvent';
-import { PlayerEventType } from 'react-native-theoplayer';
 
 export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProps>) {
   const { config, children } = props;
@@ -15,7 +13,7 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
     // Create player inside container.
     if (container.current) {
       const chromeless = config?.chromeless === true || config?.chromeless === undefined;
-      const updatedConfig = {...config, allowNativeFullscreen: true};
+      const updatedConfig = { ...config, allowNativeFullscreen: true };
       if (chromeless) {
         player.current = new THEOplayer.ChromelessPlayer(container.current, updatedConfig);
       } else {
@@ -23,7 +21,7 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
           ...updatedConfig,
           ui: {
             fluid: true,
-          }
+          },
         } as THEOplayer.PlayerConfiguration);
       }
 
@@ -48,9 +46,7 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
       if (adapter?.current && onPlayerDestroy) {
         onPlayerDestroy(adapter?.current);
       }
-      adapter?.current?.dispatchEvent(new BaseEvent(PlayerEventType.DESTROY));
       adapter?.current?.destroy();
-      player?.current?.destroy();
     };
   }, [container]);
 

--- a/src/internal/adapter/THEOplayerWebAdapter.ts
+++ b/src/internal/adapter/THEOplayerWebAdapter.ts
@@ -11,7 +11,7 @@ import type {
   TextTrackStyle,
   THEOplayer,
 } from 'react-native-theoplayer';
-import { AspectRatio, PresentationMode } from 'react-native-theoplayer';
+import { AspectRatio, PlayerEventType, PresentationMode } from 'react-native-theoplayer';
 import { THEOplayerWebAdsAdapter } from './ads/THEOplayerWebAdsAdapter';
 import { THEOplayerWebCastAdapter } from './cast/THEOplayerWebCastAdapter';
 import type * as THEOplayerWeb from 'theoplayer';
@@ -23,6 +23,7 @@ import type { PiPConfiguration } from 'src/api/pip/PiPConfiguration';
 import type { BackgroundAudioConfiguration } from 'src/api/backgroundAudio/BackgroundAudioConfiguration';
 import { WebPresentationModeManager } from './web/WebPresentationModeManager';
 import { WebMediaSession } from './web/WebMediaSession';
+import { BaseEvent } from './event/BaseEvent';
 
 const defaultBackgroundAudioConfiguration: BackgroundAudioConfiguration = {
   enabled: false,
@@ -299,11 +300,13 @@ export class THEOplayerWebAdapter extends DefaultEventDispatcher<PlayerEventMap>
   }
 
   destroy(): void {
+    this.dispatchEvent(new BaseEvent(PlayerEventType.DESTROY));
     this._eventForwarder?.unload();
     this._mediaSession?.destroy();
     document.removeEventListener('visibilitychange', this.onVisibilityChange);
     this._eventForwarder = undefined;
     this._mediaSession = undefined;
+    this._player?.destroy();
     this._player = undefined;
   }
 


### PR DESCRIPTION
On web, after the player was destroyed any references could still access the API and cause an exception to be thrown.
By shielding the player instance through the API, after it was destroyed, this can be avoided. 