### PR TITLE
Bugfix/android programdatetime msec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed an issue on Android where the `currentProgramDateTime` property of `TimeUpdateEvent` would not be formatted in milliseconds.
 - Fixed an issue on Android where the order of text and media tracks would change when adding tracks.
 - Fixed an issue on Web where an exception would be thrown when accessing the player API after the player had been destroyed.
 

--- a/android/src/main/java/com/theoplayer/util/PayloadBuilder.kt
+++ b/android/src/main/java/com/theoplayer/util/PayloadBuilder.kt
@@ -74,7 +74,8 @@ class PayloadBuilder {
     currentProgramDateTime?.let {
       payload.putDouble(
         EVENT_PROP_CURRENT_PROGRAM_DATE_TIME,
-        (1e03 * currentProgramDateTime.time).toLong().toDouble()
+        // Date.time is already formatted in msecs.
+        currentProgramDateTime.time.toDouble()
       )
     }
   }


### PR DESCRIPTION
There was an issue on Android where the currentProgramDateTime, which was already expressed in msecs, would be multiplied additionally with 1e3.

In addition, an Android SDK (v5.0.3) issue currently results in this field always being `null`.