### PR TITLE
Feature/abrstrategytype enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue on Android where the order of text and media tracks would change when adding tracks.
 - Fixed an issue on Web where an exception would be thrown when accessing the player API after the player had been destroyed.
 
+### Changed
+
+- Use `enum` instead of a string union for `ABRStrategyType`.
+
 ## [2.5.0] - 23-04-26
 
 ### Added

--- a/doc/abr.md
+++ b/doc/abr.md
@@ -21,7 +21,7 @@ on the chosen strategy, as well as various parameters of the playback buffer.
 
 ```tsx
  const onPlayerReady = (player: THEOplayer) => {
-  player.abr.strategy = 'quality';
+  player.abr.strategy = ABRStrategyType.quality;
   player.abr.targetBuffer = 20;
   player.abr.bufferLookbackWindow = 30;
   player.abr.maxBufferLength = 30;
@@ -46,7 +46,7 @@ object can be set with an estimate for the initial bitrate value (in bits per se
 
 ```typescript
 const strategyConfig: ABRStrategyConfiguration = {
-  type: 'bandwidth',
+  type: ABRStrategyType.bandwidth,
   metadata: {
     'bitrate': 1200000
   }

--- a/src/api/abr/ABRConfiguration.ts
+++ b/src/api/abr/ABRConfiguration.ts
@@ -6,7 +6,11 @@
  *
  * @public
  */
-export type ABRStrategyType = 'performance' | 'quality' | 'bandwidth';
+export enum ABRStrategyType {
+  performance = 'performance',
+  quality = 'quality',
+  bandwidth = 'bandwidth',
+}
 
 /**
  * Describes the metadata of the adaptive bitrate strategy.

--- a/src/internal/adapter/THEOplayerWebAdapter.ts
+++ b/src/internal/adapter/THEOplayerWebAdapter.ts
@@ -60,7 +60,7 @@ export class THEOplayerWebAdapter extends DefaultEventDispatcher<PlayerEventMap>
   }
 
   get abr(): ABRConfiguration | undefined {
-    return this._player?.abr;
+    return this._player?.abr as ABRConfiguration | undefined;
   }
 
   get source(): SourceDescription | undefined {


### PR DESCRIPTION
Convert string union to enum for ABRStrategyType.

Existing code using string unions will still work but show a typing error.

Note that we use lowercase enum, consistent with previous conversions, while 'older' enums are formatted with all capitals. It's best we make this consistent across the API in a future major version.