### PR TITLE
Bugfix/resilience on empty source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Approved player behaviour on iOS and Android when doing player operations such as `play` and `pause` in case no source was set.
+
 ## [2.6.0] - 23-05-05
 
 ### Fixed

--- a/src/internal/adapter/THEOplayerAdapter.ts
+++ b/src/internal/adapter/THEOplayerAdapter.ts
@@ -103,11 +103,7 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   }
 
   private onSourceChange = () => {
-    if (this._state.autoplay) {
-      this.play();
-    } else {
-      this.pause();
-    }
+    this.applyAutoplay();
   };
 
   private hasValidSource(): boolean {
@@ -229,12 +225,21 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
     return this._adsAdapter;
   }
 
+  private applyAutoplay() {
+    if (this._state.autoplay) {
+      this.play();
+    } else {
+      this.pause();
+    }
+  }
+
   set autoplay(autoplay: boolean) {
     this._state.autoplay = autoplay;
 
-    // Apply autoplay in case a source was already set
+    // Apply autoplay in case a source was already set.
+    // If autoplay is changed before setting a source, `onSourceChange` applies autoplay.
     if (this.hasValidSource()) {
-      NativeModules.PlayerModule.setPaused(this._view.nativeHandle, !autoplay);
+      this.applyAutoplay();
     }
   }
 

--- a/src/internal/adapter/THEOplayerAdapter.ts
+++ b/src/internal/adapter/THEOplayerAdapter.ts
@@ -226,6 +226,9 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   }
 
   private applyAutoplay() {
+    if (!this.hasValidSource()) {
+      return;
+    }
     if (this._state.autoplay) {
       this.play();
     } else {
@@ -238,9 +241,7 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
 
     // Apply autoplay in case a source was already set.
     // If autoplay is changed before setting a source, `onSourceChange` applies autoplay.
-    if (this.hasValidSource()) {
-      this.applyAutoplay();
-    }
+    this.applyAutoplay();
   }
 
   get autoplay(): boolean {

--- a/src/internal/adapter/THEOplayerAdapter.ts
+++ b/src/internal/adapter/THEOplayerAdapter.ts
@@ -110,6 +110,10 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
     }
   };
 
+  private hasValidSource(): boolean {
+    return this._state.source !== undefined;
+  }
+
   private onPause = () => {
     this._state.paused = true;
   };
@@ -227,7 +231,11 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
 
   set autoplay(autoplay: boolean) {
     this._state.autoplay = autoplay;
-    NativeModules.PlayerModule.setPaused(this._view.nativeHandle, !autoplay);
+
+    // Apply autoplay in case a source was already set
+    if (this.hasValidSource()) {
+      NativeModules.PlayerModule.setPaused(this._view.nativeHandle, !autoplay);
+    }
   }
 
   get autoplay(): boolean {
@@ -265,6 +273,10 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   }
 
   set currentTime(currentTime: number) {
+    if (!this.hasValidSource()) {
+      return;
+    }
+
     if (isNaN(currentTime)) {
       return;
     }
@@ -345,6 +357,9 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   }
 
   set selectedAudioTrack(trackUid: number | undefined) {
+    if (!this.hasValidSource()) {
+      return;
+    }
     this._state.selectedAudioTrack = trackUid;
     NativeModules.PlayerModule.setSelectedAudioTrack(this._view.nativeHandle, trackUid || -1);
   }
@@ -358,6 +373,9 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   }
 
   set selectedVideoTrack(trackUid: number | undefined) {
+    if (!this.hasValidSource()) {
+      return;
+    }
     this._state.selectedVideoTrack = trackUid;
     this._state.targetVideoQuality = undefined;
     NativeModules.PlayerModule.setSelectedVideoTrack(this._view.nativeHandle, trackUid || -1);
@@ -372,6 +390,9 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   }
 
   set selectedTextTrack(trackUid: number | undefined) {
+    if (!this.hasValidSource()) {
+      return;
+    }
     this._state.selectedTextTrack = trackUid;
     this.textTracks.forEach((track) => {
       if (track.uid === trackUid) {
@@ -417,6 +438,9 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   }
 
   set targetVideoQuality(target: number | number[] | undefined) {
+    if (!this.hasValidSource()) {
+      return;
+    }
     // Always pass an array for targetVideoQuality.
     this._state.targetVideoQuality = !target ? [] : Array.isArray(target) ? target : [target];
 
@@ -447,13 +471,17 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   }
 
   pause(): void {
-    this._state.paused = true;
-    NativeModules.PlayerModule.setPaused(this._view.nativeHandle, true);
+    if (this.hasValidSource()) {
+      this._state.paused = true;
+      NativeModules.PlayerModule.setPaused(this._view.nativeHandle, true);
+    }
   }
 
   play(): void {
-    this._state.paused = false;
-    NativeModules.PlayerModule.setPaused(this._view.nativeHandle, false);
+    if (this.hasValidSource()) {
+      this._state.paused = false;
+      NativeModules.PlayerModule.setPaused(this._view.nativeHandle, false);
+    }
   }
 
   get nativeHandle(): NativeHandleType {


### PR DESCRIPTION
Similar to making the player more resilient to operations after it has been destroyed, some operations should be ignored when no source is set.