### PR TITLE
Bugfix/resilience invalid view tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Approved player behaviour on iOS and Android when doing player operations such as `play` and `pause` in case no source was set.
 
+### Fixed
+
+- Fixed an issue on Android where if an invalid view tag is passed to the native bridge, it would crash the player.
+
 ## [2.6.0] - 23-05-05
 
 ### Fixed

--- a/android/src/main/java/com/theoplayer/util/ViewResolver.kt
+++ b/android/src/main/java/com/theoplayer/util/ViewResolver.kt
@@ -1,8 +1,11 @@
 package com.theoplayer.util
 
+import android.util.Log
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.uimanager.UIManagerModule
 import com.theoplayer.ReactTHEOplayerView
+
+private const val TAG = "ViewResolver"
 
 class ViewResolver(private val reactContext: ReactApplicationContext) {
   private var uiManager: UIManagerModule? = null
@@ -12,7 +15,12 @@ class ViewResolver(private val reactContext: ReactApplicationContext) {
       uiManager = reactContext.getNativeModule(UIManagerModule::class.java)
     }
     uiManager?.addUIBlock {
-      onResolved(it.resolveView(tag) as ReactTHEOplayerView)
+      try {
+        onResolved(it.resolveView(tag) as ReactTHEOplayerView)
+      } catch (ignore: Exception) {
+        // The ReactTHEOplayerView instance could not be resolved: log but do not forward exception.
+        Log.w(TAG, "Failed to resolve ReactTHEOplayerView tag $tag")
+      }
     }
   }
 }


### PR DESCRIPTION
If an invalid or unknown THEOplayerView tag is passed, an exception is thrown that should be handled instead of remaining uncaught and crashing the app.