### PR TITLE
Fix url-polyfill for web

### DIFF
--- a/src/ui/components/seekbar/thumbnail/Urlpolyfill.web.ts
+++ b/src/ui/components/seekbar/thumbnail/Urlpolyfill.web.ts
@@ -1,2 +1,3 @@
-// @ts-ignore
-export * from 'url-polyfill';
+import 'url-polyfill';
+const URL = global.URL;
+export { URL };


### PR DESCRIPTION
The 'url-polyfill' on web doesn't export anything, it's a self-executing function that polyfills global.URL.
Currently it fails due to a missing ctr.