### PR TITLE
Bugfix/android mp4 tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue on Android where play-out of an MP4 stream would sometimes crash the player.
+
 ### Changed
 
 - Improved fullscreen support to use non-native fullscreen on Safari for iPad and Mac.

--- a/android/src/main/java/com/theoplayer/track/TrackListAdapter.kt
+++ b/android/src/main/java/com/theoplayer/track/TrackListAdapter.kt
@@ -124,9 +124,11 @@ object TrackListAdapter {
     audioTrackPayload.putString(PROP_LANGUAGE, audioTrack.language)
     val qualityList = audioTrack.qualities
     val qualities = Arguments.createArray()
-    qualityList?.forEach { quality ->
-      qualities.pushMap(fromAudioQuality(quality))
-    }
+    try {
+      qualityList?.forEach { quality ->
+        qualities.pushMap(fromAudioQuality(quality))
+      }
+    } catch (ignore: NullPointerException) {}
     audioTrackPayload.putArray(PROP_QUALITIES, qualities)
     val activeQuality = audioTrack.activeQuality
     if (activeQuality != null) {
@@ -163,18 +165,20 @@ object TrackListAdapter {
     videoTrackPayload.putString(PROP_KIND, videoTrack.kind)
     videoTrackPayload.putString(PROP_LABEL, videoTrack.label)
     videoTrackPayload.putString(PROP_LANGUAGE, videoTrack.language)
-    val qualityList = videoTrack.qualities
     val qualities = Arguments.createArray()
-    if (qualityList != null) {
-      // Sort qualities according to (height, bandwidth)
-      val sortedQualityList = QualityListAdapter(qualityList)
-      sortedQualityList.sort { o: VideoQuality, t1: VideoQuality ->
-        if (o.height == t1.height) t1.bandwidth.compareTo(o.bandwidth) else t1.height.compareTo(o.height)
+    try {
+      val qualityList = videoTrack.qualities
+      if (qualityList != null) {
+        // Sort qualities according to (height, bandwidth)
+        val sortedQualityList = QualityListAdapter(qualityList)
+        sortedQualityList.sort { o: VideoQuality, t1: VideoQuality ->
+          if (o.height == t1.height) t1.bandwidth.compareTo(o.bandwidth) else t1.height.compareTo(o.height)
+        }
+        for (quality in sortedQualityList) {
+          qualities.pushMap(fromVideoQuality(quality as VideoQuality))
+        }
       }
-      for (quality in sortedQualityList) {
-        qualities.pushMap(fromVideoQuality(quality as VideoQuality))
-      }
-    }
+    } catch (ignore: java.lang.NullPointerException) {}
     videoTrackPayload.putArray(PROP_QUALITIES, qualities)
     val activeQuality = videoTrack.activeQuality
     if (activeQuality != null) {


### PR DESCRIPTION
When calling TrackList Java methods through Kotlin, the adapter would throw an NullPointerException if the tracklist was empty.