### PR TITLE
Keep track of texttrack cues

### DIFF
--- a/src/api/track/TextTrack.ts
+++ b/src/api/track/TextTrack.ts
@@ -121,13 +121,13 @@ export function hasTextTrackCue(textTrack: TextTrack, cue: TextTrackCue): boolea
   return !!(textTrack.cues && cue && textTrack.cues.find((c) => cue.uid === c.uid));
 }
 
-export function removeTextTrackCue(textTrack: TextTrack, cue: TextTrackCue) {
+export function removeTextTrackCue(textTrack?: TextTrack, cue?: TextTrackCue) {
   if (textTrack && textTrack.cues && cue && !hasTextTrackCue(textTrack, cue)) {
     textTrack.cues = textTrack.cues.filter((c) => c.uid !== cue.uid);
   }
 }
 
-export function addTextTrackCue(textTrack: TextTrack, cue: TextTrackCue) {
+export function addTextTrackCue(textTrack?: TextTrack, cue?: TextTrackCue) {
   if (textTrack && textTrack.cues && cue && !hasTextTrackCue(textTrack, cue)) {
     textTrack.cues.push(cue);
   }

--- a/src/internal/adapter/THEOplayerAdapter.ts
+++ b/src/internal/adapter/THEOplayerAdapter.ts
@@ -16,21 +16,26 @@ import type {
   RateChangeEvent,
   SourceDescription,
   TextTrack,
+  TextTrackEvent,
   TextTrackListEvent,
   THEOplayer,
   THEOplayerView,
   TimeUpdateEvent,
 } from 'react-native-theoplayer';
 import {
+  addTextTrackCue,
   addTrack,
   AspectRatio,
   findMediaTrackByUid,
+  findTextTrackByUid,
   MediaTrackEventType,
   MediaTrackType,
   PlayerEventType,
   PreloadType,
   PresentationMode,
+  removeTextTrackCue,
   removeTrack,
+  TextTrackEventType,
   TextTrackMode,
   TextTrackStyle,
   TrackListEventType,
@@ -97,6 +102,7 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
     this.addEventListener(PlayerEventType.SEEKED, this.onSeeked);
     this.addEventListener(PlayerEventType.PROGRESS, this.onProgress);
     this.addEventListener(PlayerEventType.TEXT_TRACK_LIST, this.onTextTrackList);
+    this.addEventListener(PlayerEventType.TEXT_TRACK, this.onTextTrack);
     this.addEventListener(PlayerEventType.MEDIA_TRACK, this.onMediaTrack);
     this.addEventListener(PlayerEventType.MEDIA_TRACK_LIST, this.onMediaTrackList);
     this.addEventListener(PlayerEventType.PRESENTATIONMODE_CHANGE, this.onPresentationModeChange);
@@ -155,6 +161,19 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   private onProgress = (event: ProgressEvent) => {
     this._state.seekable = event.seekable?.sort((a, b) => a.end - b.end);
     this._state.buffered = event.buffered?.sort((a, b) => a.end - b.end);
+  };
+
+  private onTextTrack = (event: TextTrackEvent) => {
+    const { subType, cue, trackUid } = event;
+    const track = findTextTrackByUid(this._state.textTracks, trackUid);
+    switch (subType) {
+      case TextTrackEventType.ADD_CUE:
+        addTextTrackCue(track, cue);
+        break;
+      case TextTrackEventType.REMOVE_CUE:
+        removeTextTrackCue(track, cue);
+        break;
+    }
   };
 
   private onTextTrackList = (event: TextTrackListEvent) => {


### PR DESCRIPTION
The list kept in `player.textTracks[0].cues` needs to be in sync in case any updates occur on the cue list.