### PR TITLE
Only filter out pause events when switching from content to ad

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed an issue on Android where play-out of an MP4 stream would sometimes crash the player.
+- Fixed an issue on Android where a `pause` event would not be dispatched while pausing during play-out of an ad.
 
 ### Changed
 

--- a/android/src/main/java/com/theoplayer/PlayerEventEmitter.kt
+++ b/android/src/main/java/com/theoplayer/PlayerEventEmitter.kt
@@ -346,7 +346,7 @@ class PlayerEventEmitter internal constructor(
   private fun onPause() {
     val player = playerView.player
     // Do not forward the pause event in case the content player is paused because the ad player starts.
-    if (player != null && !playerView.adsApi.isPlaying) {
+    if (player != null && (!playerView.adsApi.isPlaying || player.isPaused)) {
       receiveEvent(EVENT_PAUSE, null)
     }
   }


### PR DESCRIPTION
Allow pause events while playing an ad; only when switching from content to ad the redundant pause event should be filtered.