### PR TITLE
Bugfix/android foreground service crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added an overview of the available React Native connectors.
 
+### Fixed
+
+- Fixed an issue on Android where the background media service would crash the app in case it was started from the background.
+
 ## [2.8.0] - 23-06-01
 
 ### Added

--- a/android/src/main/java/com/theoplayer/media/MediaNotificationBuilder.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaNotificationBuilder.kt
@@ -11,6 +11,7 @@ import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
 import android.util.Log
 import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationCompat.FOREGROUND_SERVICE_IMMEDIATE
 import androidx.core.content.ContextCompat
 import androidx.media.session.MediaButtonReceiver
 import com.facebook.common.executors.UiThreadImmediateExecutorService
@@ -80,6 +81,10 @@ class MediaNotificationBuilder(
       }
     }
     builder.apply {
+
+      // Fix for a bug where ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK that was passed
+      // with the startForeground call got ignored.
+      foregroundServiceBehavior = FOREGROUND_SERVICE_IMMEDIATE
 
       // Add the metadata for the currently playing track
       mediaSession.controller.metadata?.description?.let {

--- a/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
@@ -260,7 +260,13 @@ class MediaPlaybackService : MediaBrowserServiceCompat() {
         // information from the session's metadata.
         // Fetch large icon asynchronously
         fetchImageFromUri(mediaSession.controller.metadata?.description?.iconUri) { largeIcon ->
-          startForeground(NOTIFICATION_ID, notificationBuilder.build(playbackState, largeIcon, enableMediaControls))
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            startForeground(NOTIFICATION_ID,
+              notificationBuilder.build(playbackState, largeIcon, enableMediaControls),
+              ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK)
+          } else {
+            startForeground(NOTIFICATION_ID, notificationBuilder.build(playbackState, largeIcon, enableMediaControls))
+          }
         }
       }
       PlaybackStateCompat.STATE_STOPPED -> {


### PR DESCRIPTION
Fix for Android API 31 and higher, where it is possible to let the app crash when starting a foreground service in case the app is backgrounded (ForegroundServiceStartNotAllowedException).