### PR TITLE
Add changelog entries from 1.8.3 and 1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,13 +248,30 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed missing `volumechange` events on mobile platforms.
 - Fixed an issue on iOS where after toggling the mute state during an ad playout, succeeding mute toggles had no effect.
 
-## [1.8.2]
+## [1.8.4] - 23-04-27
+
+### Fixed
+
+- Fixed an issue on Android where the `pause` event was not dispatched during play-out of an ad.
+
+### Added
+
+- Added a `videoAspectRatio` property on the `THEOplayerView` for iOS and Android.
+- Added a `PlayerEventTypes.WAITING` event that is dispatched when play-back stops due to lack of media data.
+
+## [1.8.3] - 23-04-06
+
+### Fixed
+
+- Fixed an issue on Android where building the SDK would fail when depending on player SDK v5.x.
+
+## [1.8.2] - 23-04-05
 
 ### Fixed
 
 - Fixed an issue on Android where building the SDK would fail when depending on player SDK v4.12.0.
 
-## [1.8.1]
+## [1.8.1] - 23-02-09
 
 ### Changed
 
@@ -267,7 +284,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue on iOS where the player was not destroyed correctly on the iOS bridge.
 - Added support for `DRMConfig` through `SourceDescription` for SSAI sources on iOS.
 
-## [1.8.0]
+## [1.8.0] - 23-01-16
 
 ### Added
 
@@ -282,20 +299,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Upgraded Web SDK to v4.6.0.
 - Updated the custom build setup to support both iOS and tvOS.
 
-## [1.7.2]
+## [1.7.2] - 22-12-05
 
 ### Fixed
 
 - Fixed an issue on tvOS where a feature flag was incorrectly used for ads-related code.
 
-## [1.7.1]
+## [1.7.1] - 22-11-28
 
 ### Fixed
 
 - Fixed an issue on Android where the player would consider unusable custom drm integrations.
 - Fixed missing kotlin classpath property on Android.
 
-## [1.7.0]
+## [1.7.0] - 22-11-23
 
 ### Added
 
@@ -313,13 +330,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue in the example app where it would not be possible to select a specific text track.
 - Fixed conflicting npm dependencies in the example app.
 
-## [1.6.1]
+## [1.6.1] - 22-10-07
 
 ### Added
 
 - Improved source handling for iOS.
 
-## [1.6.0]
+## [1.6.0] - 22-09-28
 
 ### Fixed
 
@@ -331,7 +348,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Excluded folders from bob build config.
 - Upgraded gradle versions for Android.
 
-## [1.5.0]
+## [1.5.0] - 22-09-26
 
 ### Fixed
 
@@ -343,7 +360,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Support for DRM pre-integrations on Android.
 - Support for additional source properties on Android: `liveOffset`, `hlsDateRange`, `timeServer` and `hls`.
 
-## [1.4.0]
+## [1.4.0] - 22-08-11
 
 ### Fixed
 
@@ -354,7 +371,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Improved determination of the stream source type on Android.
 
-## [1.3.0]
+## [1.3.0] - 22-07-26
 
 ### Fixed
 
@@ -363,7 +380,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed documentation feature matrix.
 - Fixed duration scale in loadedmetadata event properties for Web.
 
-## [1.2.0]
+## [1.2.0] - 22-06-30
 
 ### Fixed
 
@@ -371,7 +388,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a number of broken links in the documentation.
 - Removed unused files.
 
-## [1.1.0]
+## [1.1.0] - 22-06-06
 
 ### Added
 


### PR DESCRIPTION
Changelog entries from 1.8.x versions released after 2.x live on a separate branch and don't have their changelog entries inside the main changelog file.
This PR adds them separately.