### PR TITLE
Bugfix/android pip eventlisteners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed an issue on Android where the media button receiver would not accept button events in case multiple receivers are registered.
+- Fixed an issue on Android where `react-native-theoplayer` would not build when depending on Android player SDK v5.6.0.
 
 ### Changed
 

--- a/android/src/main/java/com/theoplayer/presentation/PipUtils.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PipUtils.kt
@@ -46,8 +46,8 @@ class PipUtils(
 ) {
 
   private var enabled: Boolean = false
-  private var onPlayerAction: EventListener<PlayerEvent<*>>? = null
-  private var onAdAction: EventListener<GoogleImaAdEvent>? = null
+  private var onPlayerAction: EventListener<PlayerEvent<*>>
+  private var onAdAction: EventListener<GoogleImaAdEvent>
   private val playerEvents = listOf(PlayerEventTypes.PLAY, PlayerEventTypes.PAUSE)
   private var adEvents = listOf<GoogleImaAdEventType>()
   private val broadcastReceiver: BroadcastReceiver = buildBroadcastReceiver()


### PR DESCRIPTION
Fix an issue with Android SDK v5.6.0: all modules in the native player SDK were upgraded to Java 1.8.0, which was breaking Kotlin code.