### PR TITLE
Feature/analytics source description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added an `AnalyticsDescription` property to `SourceDescription` to configure additional source-specific properties for analytics connectors.
+
 ## [2.11.0] - 23-08-10
 
 ### Added

--- a/src/api/source/SourceDescription.ts
+++ b/src/api/source/SourceDescription.ts
@@ -12,6 +12,7 @@ import type { HlsPlaybackConfiguration } from './hls/HlsPlaybackConfiguration';
 import type { AdDescription } from './ads/Ads';
 import type { MetadataDescription } from './metadata/MetadataDescription';
 import type { ServerSideAdInsertionConfiguration } from "./ads/ssai/ServerSideAdInsertionConfiguration";
+import type { AnalyticsDescription } from "./analytics/AnalyticsDescription";
 
 export type Source = TypedSource;
 
@@ -87,6 +88,11 @@ export interface SourceConfiguration {
    * @public
    */
   metadata?: MetadataDescription;
+
+  /**
+   * List of {@link AnalyticsDescription}s to configure source-related properties for analytics connectors.
+   */
+  analytics?: AnalyticsDescription[];
 }
 
 /**

--- a/src/api/source/analytics/AnalyticsDescription.ts
+++ b/src/api/source/analytics/AnalyticsDescription.ts
@@ -1,0 +1,16 @@
+/**
+ * Describes the configuration of an analytics integration as part of the SourceDescription.
+ *
+ * @public
+ */
+export interface AnalyticsDescription {
+  /**
+   * The identifier of the analytics integration.
+   */
+  integration: string;
+
+  /**
+   * Analytics extensions can define any custom set of fields.
+   */
+  [key: string]: unknown;
+}

--- a/src/api/source/analytics/barrel.ts
+++ b/src/api/source/analytics/barrel.ts
@@ -1,0 +1,1 @@
+export * from './AnalyticsDescription';

--- a/src/api/source/barrel.ts
+++ b/src/api/source/barrel.ts
@@ -1,4 +1,5 @@
 export * from './ads/barrel';
+export * from './analytics/barrel';
 export * from './drm/barrel';
 export * from './dash/barrel';
 export * from './hls/barrel';

--- a/src/internal/adapter/THEOplayerWebAdapter.ts
+++ b/src/internal/adapter/THEOplayerWebAdapter.ts
@@ -71,7 +71,7 @@ export class THEOplayerWebAdapter extends DefaultEventDispatcher<PlayerEventMap>
   set source(source: SourceDescription | undefined) {
     this._targetVideoQuality = undefined;
     if (this._player) {
-      this._player.source = source;
+      this._player.source = source as THEOplayerWeb.SourceDescription;
     }
   }
 


### PR DESCRIPTION
Added the possibility to configure analytics properties in the source description.
These can be picked up by analytics connectors on source changes, without the need to pass them separately to the connector.