### PR TITLE
Install default NoOp for onBuildProcessed event

### DIFF
--- a/android/src/main/java/com/theoplayer/drm/ContentProtectionModule.kt
+++ b/android/src/main/java/com/theoplayer/drm/ContentProtectionModule.kt
@@ -111,7 +111,7 @@ class ContentProtectionModule(private val context: ReactApplicationContext) :
     }
     emit(
       EVENT_BUILD_INTEGRATION, payload,
-      onResult = hashMapOf(),
+      onResult = hashMapOf(EVENT_BUILD_PROCESSED to { /*NoOp*/ }),
       onError = {}
     )
   }


### PR DESCRIPTION
This fix does not affect the ContentProtection flow. When a ContentProtection integration is created, a NoOp result callback should be called instead of a NoOp error callback.