### PR TITLE
Bugfix/android reset source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added an `AnalyticsDescription` property to `SourceDescription` to configure additional source-specific properties for analytics connectors.
 
+### Fixed
+
+- Fixed an issue on Android that would cause the player not to reset when setting an empty source.
+
 ## [2.11.0] - 23-08-10
 
 ### Added

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerView.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerView.kt
@@ -130,9 +130,7 @@ class ReactTHEOplayerView(private val reactContext: ThemedReactContext) :
     try {
       val sourceDescription = SourceAdapter().parseSourceFromJS(source)
       adsApi.setSource(sourceDescription)
-      if (sourceDescription != null) {
-        player?.source = sourceDescription
-      }
+      player?.source = sourceDescription
     } catch (exception: THEOplayerException) {
       Log.e(TAG, exception.message ?: "")
       eventEmitter.emitError(exception)


### PR DESCRIPTION
A `player.source = undefined` wouldn't reach the native Android SDK, which would mean the current asset would still be kept, and potentially still buffering ahead for a short period.