### PR TITLE
Bugfix/android audiofocus hostresume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- When resuming an app on Android, retrieve audio focus only if the player is not paused.
+
+### Fixed
+
 - Fixed an issue on Android where during play-out of a locally stored media asset the `seekable` property would not update.
 
 ## [3.0.2] - 23-10-17

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -379,7 +379,9 @@ class ReactTHEOplayerContext private constructor(
     isHostPaused = false
     mediaSessionConnector?.setActive(true)
     playerView.onResume()
-    audioFocusManager?.retrieveAudioFocus()
+    if (!player.isPaused) {
+      audioFocusManager?.retrieveAudioFocus()
+    }
   }
 
   fun destroy() {


### PR DESCRIPTION
Change in Android's audio focus policy: when resuming an app, only request focus when play-out has actually started.