### PR TITLE
Maintenance/android playbackservice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - When resuming an app on Android, retrieve audio focus only if the player is not paused.
+- Changed the behaviour of the Android component supporting background playback. It is stopped but not disabled when setting `backgroundAudioConfiguration.enabled = true`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- When resuming an app on Android, retrieve audio focus only if the player is not paused.
+- Revised audio focus protocol on Android. When resuming an app, audio focus is retrieved only if the player is not paused.
 - Changed the behaviour of the Android component supporting background playback. It is stopped but not disabled when setting `backgroundAudioConfiguration.enabled = true`.
 
 ### Fixed

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
       android:name="com.theoplayer.media.MediaPlaybackService"
       android:description="@string/background_playback_service_description"
       android:exported="false"
-      android:enabled="false"
+      android:enabled="true"
       android:foregroundServiceType="mediaPlayback">
       <intent-filter>
         <action android:name="android.media.browse.MediaBrowserService" />

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -73,7 +73,7 @@ class ReactTHEOplayerContext private constructor(
   var imaIntegration: GoogleImaIntegration? = null
   var castIntegration: CastIntegration? = null
   var wasPlayingOnHostPause: Boolean = false
-  var isHostPaused: Boolean = false
+  private var isHostPaused: Boolean = false
 
   private val isBackgroundAudioEnabled: Boolean
     get() = backgroundAudioConfig.enabled


### PR DESCRIPTION
Simplified background playback service logic.

In response to toggling the backgroundAudioConfiguration.enabled property, we've refined the approach by refraining from enabling or disabling the MediaBrowserServiceCompat component. Originally, this was intended to facilitate the coexistence of multiple MediaBrowserServiceCompat instances within the same application.

Given that only one MediaBrowserServiceCompat instance is allowed to exist, our decision to disable it was necessary. Should there still be a requirement for multiple MediaBrowserServiceCompat instances, external deactivation is now the recommended approach.