### PR TITLE
Bugfix/android audio selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue on iOS and Android were selecting an audio, video or text track that has a `uid` with value `0`, would fail.
+
 ## [3.1.0] - 23-10-27
 
 ### Changed

--- a/android/src/main/java/com/theoplayer/player/PlayerModule.kt
+++ b/android/src/main/java/com/theoplayer/player/PlayerModule.kt
@@ -98,6 +98,10 @@ class PlayerModule(context: ReactApplicationContext) : ReactContextBaseJavaModul
 
   @ReactMethod
   fun setSelectedAudioTrack(tag: Int, uid: Int) {
+    if (uid == -1) {
+      // Do not allow disabling all audio tracks
+      return
+    }
     viewResolver.resolveViewByTag(tag) { view: ReactTHEOplayerView? ->
       view?.player?.let {
         for (track in it.audioTracks) {
@@ -109,6 +113,10 @@ class PlayerModule(context: ReactApplicationContext) : ReactContextBaseJavaModul
 
   @ReactMethod
   fun setSelectedVideoTrack(tag: Int, uid: Int) {
+    if (uid == -1) {
+      // Do not allow disabling all video tracks
+      return
+    }
     viewResolver.resolveViewByTag(tag) { view: ReactTHEOplayerView? ->
       view?.player?.let {
         for (track in it.videoTracks) {

--- a/src/internal/adapter/THEOplayerAdapter.ts
+++ b/src/internal/adapter/THEOplayerAdapter.ts
@@ -391,7 +391,7 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
       return;
     }
     this._state.selectedAudioTrack = trackUid;
-    NativeModules.PlayerModule.setSelectedAudioTrack(this._view.nativeHandle, trackUid || -1);
+    NativeModules.PlayerModule.setSelectedAudioTrack(this._view.nativeHandle, (trackUid !== undefined) ? trackUid : -1);
   }
 
   get videoTracks(): MediaTrack[] {
@@ -408,7 +408,7 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
     }
     this._state.selectedVideoTrack = trackUid;
     this._state.targetVideoQuality = undefined;
-    NativeModules.PlayerModule.setSelectedVideoTrack(this._view.nativeHandle, trackUid || -1);
+    NativeModules.PlayerModule.setSelectedVideoTrack(this._view.nativeHandle, (trackUid !== undefined) ? trackUid : -1);
   }
 
   get textTracks(): TextTrack[] {
@@ -431,7 +431,7 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
         track.mode = TextTrackMode.disabled;
       }
     });
-    NativeModules.PlayerModule.setSelectedTextTrack(this._view.nativeHandle, trackUid || -1);
+    NativeModules.PlayerModule.setSelectedTextTrack(this._view.nativeHandle, (trackUid !== undefined) ? trackUid : -1);
   }
 
   get textTrackStyle(): TextTrackStyle {


### PR DESCRIPTION
This issue also impact iOS, and is occurring for audio, video and text tracks. Apparently the `uid==0` case was rare enough not to get noticed until now.