### PR TITLE
Print exception details in ViewResolver catch

### DIFF
--- a/android/src/main/java/com/theoplayer/util/ViewResolver.kt
+++ b/android/src/main/java/com/theoplayer/util/ViewResolver.kt
@@ -22,9 +22,9 @@ class ViewResolver(private val reactContext: ReactApplicationContext) {
     uiManager?.addUIBlock {
       try {
         onResolved(it.resolveView(tag) as ReactTHEOplayerView)
-      } catch (ignore: Exception) {
+      } catch (e: Exception) {
         // The ReactTHEOplayerView instance could not be resolved: log but do not forward exception.
-        Log.w(TAG, "Failed to resolve ReactTHEOplayerView tag $tag")
+        Log.e(TAG, "Failed to resolve ReactTHEOplayerView tag $tag: $e")
         onResolved(null)
       }
     }


### PR DESCRIPTION
I experienced an issue where MuxStatsSDKTHEOPlayer was throwing an exception, but it was impossible to know what was happening without stepping into a debugger because the exception was not printed anywhere.

For my particular problem, this changes my log message from

```
W  Failed to resolve ReactTHEOplayerView tag 17097
```

to

```
E   Failed to resolve ReactTHEOplayerView tag 17097: com.facebook.react.bridge.UnexpectedNativeTypeException: Value for video_id cannot be cast from Double to String
```

And now I can solve the problem