### PR TITLE
Feature/android cue track uid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue on Android where `EnterCue` and `ExitCue` text track events did not contain the `trackUid` property.
+
 ## [3.2.0] - 23-11-29
 
 ### Fixed

--- a/android/src/main/java/com/theoplayer/PlayerEventEmitter.kt
+++ b/android/src/main/java/com/theoplayer/PlayerEventEmitter.kt
@@ -437,14 +437,14 @@ class PlayerEventEmitter internal constructor(
   }
 
   private val onTextTrackEnterCue = EventListener<EnterCueEvent> { event ->
-    val payload = PayloadBuilder().textTrackCue(event.cue, null /*TODO*/).build().apply {
+    val payload = PayloadBuilder().textTrackCue(event.cue, event.track).build().apply {
       putInt(EVENT_PROP_TYPE, TextTrackCueEventType.ENTER_CUE.type)
     }
     receiveEvent(EVENT_TEXTTRACK_EVENT, payload)
   }
 
   private val onTextTrackExitCue = EventListener<ExitCueEvent> { event ->
-    val payload = PayloadBuilder().textTrackCue(event.cue, null /*TODO*/).build().apply {
+    val payload = PayloadBuilder().textTrackCue(event.cue, event.track).build().apply {
       putInt(EVENT_PROP_TYPE, TextTrackCueEventType.EXIT_CUE.type)
     }
     receiveEvent(EVENT_TEXTTRACK_EVENT, payload)


### PR DESCRIPTION
Fixed missing track uid on enter cue and exit cue events, for Android.