### PR TITLE
Feature/Android: add build flag to make re-parenting optional

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -49,6 +49,9 @@ android {
     def TimeUpdateRate = "com.theoplayer.TimeUpdateRate"
     buildConfigField TimeUpdateRate, "TIMEUPDATE_RATE", safeExtGet('THEOplayer_timeUpdateRate', "${TimeUpdateRate}.UNLIMITED")
 
+    // Optionally re-parent player view on fullscreen event
+    buildConfigField "boolean", "REPARENT_ON_FULLSCREEN", "${safeExtGet('THEOplayer_reparent_on_fullscreen', 'true')}"
+
     // Optionally log events to logcat
     buildConfigField "boolean", "LOG_PLAYER_EVENTS", "${safeExtGet('THEOplayer_logPlayerEvents', 'false')}"
     buildConfigField "boolean", "LOG_VIEW_EVENTS", "${safeExtGet('THEOplayer_logViewEvents', 'false')}"

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -18,6 +18,7 @@ import androidx.lifecycle.Lifecycle
 import com.facebook.react.ReactRootView
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
+import com.theoplayer.BuildConfig
 import com.theoplayer.PlayerEventEmitter
 import com.theoplayer.ReactTHEOplayerContext
 import com.theoplayer.android.api.error.ErrorCode
@@ -208,6 +209,9 @@ class PresentationManager(
       }.hide(WindowInsetsCompat.Type.systemBars())
       updatePresentationMode(PresentationMode.FULLSCREEN)
 
+      if (!BuildConfig.REPARENT_ON_FULLSCREEN) {
+        return
+      }
       playerGroupParentNode = (reactPlayerGroup?.parent as ReactViewGroup?)?.also { parent ->
         playerGroupChildIndex = parent.indexOfChild(reactPlayerGroup)
         // Re-parent the playerViewGroup to the root node
@@ -220,6 +224,9 @@ class PresentationManager(
       )
       updatePresentationMode(PresentationMode.INLINE)
 
+      if (!BuildConfig.REPARENT_ON_FULLSCREEN) {
+        return
+      }
       root?.run {
         // Re-parent the playerViewGroup from the root node to its original parent
         removeView(reactPlayerGroup)


### PR DESCRIPTION
Theo introduced re-parenting in the [commit](https://github.com/THEOplayer/react-native-theoplayer/commit/f805fb93fa46bdbbb1fa81d79db128c3043de91b) to improve Android fullscreen API. This PR adds a build flag to make it optional but still enabled by default.

Test steps:
1. Build and run the test app with flag `THEOplayer_reparent_on_fullscreen=false` in gradle.properties
2. Switch the video player to fullscreen
3. Expected: It shouldn't reparent the video to the root on fullscreen event and vice versa