### PR TITLE
Feature/iOS: update NowPlayingInfo API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Updated dependencies and example app to support ReactNative v0.73.
 
+### Fixed
+
+- Improved NowPlayingInfo updates for iOS by setting playbackRate on pause/playing events and processing the final info on player desctruction.
+
 ## [3.9.2] - 24-03-06
 
 ### Changed

--- a/ios/backgroundAudio/THEOplayerRCTNowPlayingManager.swift
+++ b/ios/backgroundAudio/THEOplayerRCTNowPlayingManager.swift
@@ -197,7 +197,7 @@ class THEOplayerRCTNowPlayingManager {
         self.playingListener = player.addEventListener(type: PlayerEventTypes.PLAYING) { [weak self, weak player] event in
             if let welf = self,
                let wplayer = player {
-                welf.updatePlaybackRate(1)
+                welf.updatePlaybackRate(wplayer.playbackRate)
                 welf.updatePlaybackState()
                 welf.updateCurrentTime(wplayer.currentTime)
                 if DEBUG_NOWINFO { PrintUtils.printLog(logText: "[NATIVE] PLAYING: Updating playbackState and time on NowPlayingInfoCenter...") }


### PR DESCRIPTION
**Summary:**

This PR does the following:

- copies the self.nowPlayingInfo to local const in processNowPlayingToInfoCenter(...) to make the method thread safe
- sets playback rate to expected values: to 0 on pause and to 1 on resume
- updates elapsed time before close

**Test-Plan:**

No UI elements are changed so the test plan is to verify the appropriate values in MPNowPlayingInfoCenter.default().nowPlayingInfo on pause, on resume and on close in debug mode in XCode.