### PR TITLE
Maintenance/lock ios sdk version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Updated dependencies and example app to support ReactNative v0.73.
+- Updated ios sdk version to 6.11
 
 ### Fixed
 

--- a/react-native-theoplayer.podspec
+++ b/react-native-theoplayer.podspec
@@ -41,20 +41,20 @@ Pod::Spec.new do |s|
     }
   else 
   	puts "Using THEOplayer-core SDK"
-    s.dependency "THEOplayerSDK-core", "~> 6.9"
+    s.dependency "THEOplayerSDK-core", "6.11"
     if theofeatures.include?("GOOGLE_IMA") 
 	  puts "Adding THEOplayer-Integration-GoogleIMA"
-      s.dependency "THEOplayer-Integration-GoogleIMA/Base", "~> 6.9"
-	  s.dependency "THEOplayer-Integration-GoogleIMA/Dependencies", "~> 6.9"
+      s.dependency "THEOplayer-Integration-GoogleIMA/Base", "6.11"
+	  s.dependency "THEOplayer-Integration-GoogleIMA/Dependencies", "6.11"
     end
     if theofeatures.include?("CHROMECAST")
 	  puts "Adding THEOplayer-Integration-GoogleCast"
-      s.ios.dependency "THEOplayer-Integration-GoogleCast/Base", "~> 6.9"
+      s.ios.dependency "THEOplayer-Integration-GoogleCast/Base", "6.11"
 	  s.ios.dependency "google-cast-sdk-dynamic-xcframework", "~> 4.8"
     end
     if theofeatures.include?("SIDELOADED_TEXTTRACKS") 
 	  puts "Adding THEOplayer-Connector-SideloadedSubtitle"
-      s.dependency "THEOplayer-Connector-SideloadedSubtitle", "~> 6.9"
+      s.dependency "THEOplayer-Connector-SideloadedSubtitle", "6.11"
     end
   end
   


### PR DESCRIPTION
Locking the ios sdk to v6.11.0. 
This should prevent users from installing the 6.12 SDK that currently contains build issues.