### PR TITLE
Maintenance/support target sdk 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.10.2] - 24-03-21
+
+### Changed
+
+- Downgraded default `androidx.core:core-ktx` dependency version to support Android target sdk 33.
+
 ## [3.10.1] - 24-03-19
 
 ### Changed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:8.2.2'
+    classpath "com.android.tools.build:gradle:${safeExtGet('gradlePluginVersion', '8.2.2')}"
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${safeExtGet('kotlinVersion', '1.9.21')}"
   }
 }
@@ -108,9 +108,9 @@ repositories {
 dependencies {
   //noinspection GradleDynamicVersion
   implementation "com.facebook.react:react-native:+"  // From node_modules
-  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
-  implementation "androidx.appcompat:appcompat:1.6.1"
-  implementation "androidx.core:core-ktx:1.12.0"
+  implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${safeExtGet('coroutinesVersion', '1.7.3')}"
+  implementation "androidx.appcompat:appcompat:${safeExtGet('appcompatVersion', '1.6.1')}"
+  implementation "androidx.core:core-ktx:${safeExtGet('corektxVersion', '1.12.0')}"
 
   // The minimum supported THEOplayer version is 6.0.0
   def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[6.0.0,7.0)')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -110,7 +110,7 @@ dependencies {
   implementation "com.facebook.react:react-native:+"  // From node_modules
   implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${safeExtGet('coroutinesVersion', '1.7.3')}"
   implementation "androidx.appcompat:appcompat:${safeExtGet('appcompatVersion', '1.6.1')}"
-  implementation "androidx.core:core-ktx:${safeExtGet('corektxVersion', '1.12.0')}"
+  implementation "androidx.core:core-ktx:${safeExtGet('corektxVersion', '1.10.1')}"
 
   // The minimum supported THEOplayer version is 6.0.0
   def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[6.0.0,7.0)')

--- a/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
@@ -293,13 +293,18 @@ class MediaPlaybackService : MediaBrowserServiceCompat() {
 
   private fun startForegroundWithPlaybackState(@PlaybackStateCompat.State playbackState: Int, largeIcon: Bitmap? = null) {
     try {
-      ServiceCompat.startForeground(
-        this, NOTIFICATION_ID,
-        notificationBuilder.build(playbackState, largeIcon, enableMediaControls),
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        startForeground(
+          NOTIFICATION_ID,
+          notificationBuilder.build(playbackState, largeIcon, enableMediaControls),
           ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK
-        else 0
-      )
+        )
+      } else {
+        startForeground(
+          NOTIFICATION_ID,
+          notificationBuilder.build(playbackState, largeIcon, enableMediaControls)
+        )
+      }
     } catch (e: IllegalStateException) {
       // Make sure that app does not crash in case anything goes wrong with starting the service.
       // https://issuetracker.google.com/issues/229000935


### PR DESCRIPTION
Targeting sdk 33 resulted in some build errors
- androidx.core:core-ktx was downgraded, and made configurable;
- `ServiceCompat.startForeground` is only available as of sdk v34; it was replaced with `Service.startForeground`.