### PR TITLE
Update links to THEOplayer documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed an issue where the player had the wrong layout in fullscreen presentationMode, after changing the source.
-- Fixed an issue where not enabling autoplay would explicitely pause the stream, reverting a possible play() request right after setting up the source. 
+- Fixed an issue where not enabling autoplay would explicitely pause the stream, reverting a possible play() request right after setting up the source.
 
 ## [3.10.3] - 24-03-22
 
@@ -203,7 +203,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- Added support for THEOplayer 6.0. See [THEOplayer's changelog](https://docs.theoplayer.com/changelog.md) for details.
+- Added support for THEOplayer 6.0. See [THEOplayer's changelog](https://www.theoplayer.com/docs/theoplayer/changelog/) for details.
 - Bumped minimal version for SideloadedTextTracks connection on iOS to v6.1.1 which contains fix for iOS 17.0.
 
 ### Added

--- a/doc/ads.md
+++ b/doc/ads.md
@@ -3,10 +3,10 @@
 ## Overview
 
 A good starting point to get acquainted with THEOplayer's advertising features
-is THEOplayer's [Knowledge Base](https://docs.theoplayer.com/knowledge-base/01-advertisement/01-user-guide.md).
+is THEOplayer's [Knowledge Base](https://www.theoplayer.com/docs/theoplayer/knowledge-base/advertisement/user-guide/).
 
 While THEOplayer supports a wide range of
-different [ad types](https://docs.theoplayer.com/knowledge-base/01-advertisement/01-user-guide.md#an-overview-of-theoplayers-different-ad-types),
+different [ad types](https://www.theoplayer.com/docs/theoplayer/knowledge-base/advertisement/user-guide/#an-overview-of-theoplayers-different-ad-types),
 `THEOplayerView` currently supports:
 
 - client-side ad insertion (CSAI) through [Google IMA](#getting-started-with-google-ima)

--- a/doc/cast.md
+++ b/doc/cast.md
@@ -3,7 +3,7 @@
 ## Overview
 
 The basics of both Chromecast and Airplay are well-described in
-THEOplayer's [Knowledge Base](https://docs.theoplayer.com/how-to-guides/03-cast/01-chromecast/00-introduction.md).
+THEOplayer's [Knowledge Base](https://www.theoplayer.com/docs/theoplayer/how-to-guides/cast/chromecast/introduction/).
 The `react-native-theoplayer` package has support for both.
 
 This page first outlines the setup

--- a/doc/creating-minimal-app.md
+++ b/doc/creating-minimal-app.md
@@ -203,7 +203,7 @@ We refer to the [example application](example-app.md) and its [code](https://git
 ### libraryConfiguration
 
 When passing the `PlayerConfiguration` object while creating the player, the
-[`libraryConfiguration`](https://www.theoplayer.com/docs/theoplayer/v6/api-reference/web/interfaces/PlayerConfiguration.html#libraryLocation) parameter specifies
+[`libraryConfiguration`](https://www.theoplayer.com/docs/theoplayer/v7/api-reference/web/interfaces/PlayerConfiguration.html#libraryLocation) parameter specifies
 where the THEOplayer web worker files are located. The worker files are dynamically loaded and
 necessary to play-out MPEG-TS based HLS streams. By default it is set to the location where npm installed THEOplayer
 ('./node_modules/theoplayer').

--- a/doc/creating-minimal-app.md
+++ b/doc/creating-minimal-app.md
@@ -203,7 +203,7 @@ We refer to the [example application](example-app.md) and its [code](https://git
 ### libraryConfiguration
 
 When passing the `PlayerConfiguration` object while creating the player, the
-[`libraryConfiguration`](https://docs.theoplayer.com/api-reference/web/theoplayer.playerconfiguration.md#librarylocation) parameter specifies
+[`libraryConfiguration`](https://www.theoplayer.com/docs/theoplayer/v6/api-reference/web/interfaces/PlayerConfiguration.html#libraryLocation) parameter specifies
 where the THEOplayer web worker files are located. The worker files are dynamically loaded and
 necessary to play-out MPEG-TS based HLS streams. By default it is set to the location where npm installed THEOplayer
 ('./node_modules/theoplayer').

--- a/doc/drm.md
+++ b/doc/drm.md
@@ -4,7 +4,7 @@
 
 This section outlines how play-out of DRM protected content can be achieved with `react-native-theoplayer`.
 A detailed explanation on how DRM (Digital Rights Management) works can be found in
-[THEOplayer's knowledge base](https://docs.theoplayer.com/knowledge-base/02-content-protection/00-introduction.md).
+[THEOplayer's knowledge base](https://www.theoplayer.com/docs/theoplayer/knowledge-base/content-protection/introduction/).
 
 ## Configuration
 
@@ -40,7 +40,7 @@ const onReady = (player: THEOplayer) => {
 
 ### Pre-integrations
 
-THEOplayer is [pre-integrated](https://docs.theoplayer.com/how-to-guides/04-drm/00-introduction.md#pre-integrations)
+THEOplayer is [pre-integrated](https://www.theoplayer.com/docs/theoplayer/how-to-guides/drm/introduction/#pre-integrations)
 with a number of commercial multi-DRM vendors, which means support for these vendors is already included
 and enabled in the SDK.
 

--- a/doc/theoplayerview-component.md
+++ b/doc/theoplayerview-component.md
@@ -74,7 +74,7 @@ created in React Native. The accompanying example application provides a basic U
 
 You can set a source using the `source` property on the [THEOplayer API](../src/api/player/THEOplayer.ts). The type
 definition of `SourceDescription` maps to the type used in
-the [Web SDK's documentation](https://www.theoplayer.com/docs/theoplayer/v6/api-reference/web/interfaces/SourceDescription.html).
+the [Web SDK's documentation](https://www.theoplayer.com/docs/theoplayer/v7/api-reference/web/interfaces/SourceDescription.html).
 
 ```typescript
 player.source = {

--- a/doc/theoplayerview-component.md
+++ b/doc/theoplayerview-component.md
@@ -74,7 +74,7 @@ created in React Native. The accompanying example application provides a basic U
 
 You can set a source using the `source` property on the [THEOplayer API](../src/api/player/THEOplayer.ts). The type
 definition of `SourceDescription` maps to the type used in
-the [Web SDK's documentation](https://docs.theoplayer.com/api-reference/web/theoplayer.sourcedescription.md).
+the [Web SDK's documentation](https://www.theoplayer.com/docs/theoplayer/v6/api-reference/web/interfaces/SourceDescription.html).
 
 ```typescript
 player.source = {

--- a/typedoc.config.js
+++ b/typedoc.config.js
@@ -17,7 +17,7 @@ module.exports = {
   externalDocumentation: {
     theoplayer: {
       dtsPath: '~/THEOplayer.d.ts',
-      externalBaseURL: 'https://www.theoplayer.com/docs/theoplayer/v6/api-reference/web',
+      externalBaseURL: 'https://www.theoplayer.com/docs/theoplayer/v7/api-reference/web',
     },
   },
 };


### PR DESCRIPTION
Update all links for `docs.theoplayer.com` to the new `www.theoplayer.com/docs` website.