### PR TITLE
Feature/android mediasession config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `skipForwardInterval` and `skipBackwardInterval` properties to `MediaControlConfiguration` for Android and Web, enabling configurable skip intervals for media sessions.
+
 ## [7.0.0] - 24-04-10
 
 ### Fixed

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -118,14 +118,7 @@ dependencies {
   println("Using THEOplayer (${versionString(theoplayer_sdk_version)})")
   implementation "com.theoplayer.theoplayer-sdk-android:core:${theoplayer_sdk_version}"
   implementation "com.theoplayer.theoplayer-sdk-android:ads-wrapper:6.10.0"
-
-  if (enabledMediaSession) {
-    println("Enable THEOplayer MediaSession extension (${versionString(theoplayer_sdk_version)})")
-    implementation "com.theoplayer.android-connector:mediasession:${theoplayer_sdk_version}"
-  } else {
-    println('Disable THEOplayer MediaSession extension.')
-    compileOnly "com.theoplayer.android-connector:mediasession:${theoplayer_sdk_version}"
-  }
+  implementation "com.theoplayer.android-connector:mediasession:${theoplayer_sdk_version}"
 
   if (enabledGoogleIMA) {
     println('Enable THEOplayer IMA extension.')

--- a/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
+++ b/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
@@ -11,6 +11,7 @@ import com.theoplayer.android.api.cast.CastConfiguration
 import com.theoplayer.android.api.pip.PipConfiguration
 import com.theoplayer.android.api.player.NetworkConfiguration
 import com.theoplayer.android.api.ui.UIConfiguration
+import com.theoplayer.media.MediaSessionConfig
 
 private const val PROP_LICENSE = "license"
 private const val PROP_LICENSE_URL = "licenseUrl"
@@ -27,6 +28,9 @@ private const val PROP_RETRY_MAX_BACKOFF = "maximumBackoff"
 private const val PROP_CAST_CONFIGURATION = "cast"
 private const val PROP_ADS_CONFIGURATION = "ads"
 private const val PROP_UI_CONFIGURATION = "ui"
+private const val PROP_MEDIASESSION_ENABLED = "mediaSessionEnabled"
+private const val PROP_SKIP_FORWARD_INTERVAL = "skipForwardInterval"
+private const val PROP_SKIP_BACKWARD_INTERVAL = "skipBackwardInterval"
 
 class PlayerConfigAdapter(private val configProps: ReadableMap?) {
 
@@ -152,6 +156,28 @@ class PlayerConfigAdapter(private val configProps: ReadableMap?) {
       "manual" -> CastStrategy.MANUAL
       "disabled" -> CastStrategy.DISABLED
       else -> null
+    }
+  }
+
+  /**
+   * Get MediaSession connector configuration; these properties apply:
+   * - mediaSessionEnabled: whether or not the media session should be enabled.
+   * - skipForwardInterval: the amount of seconds the player will skip forward.
+   * - skipBackwardInterval: the amount of seconds the player will skip backward.
+   */
+  fun mediaSessionConfig(): MediaSessionConfig {
+    return MediaSessionConfig().apply {
+      configProps?.run {
+        if (hasKey(PROP_MEDIASESSION_ENABLED)) {
+          mediaSessionEnabled = getBoolean(PROP_MEDIASESSION_ENABLED)
+        }
+        if (hasKey(PROP_SKIP_FORWARD_INTERVAL)) {
+          skipForwardInterval = getDouble(PROP_SKIP_FORWARD_INTERVAL)
+        }
+        if (hasKey(PROP_SKIP_BACKWARD_INTERVAL)) {
+          skipBackwardInterval = getDouble(PROP_SKIP_BACKWARD_INTERVAL)
+        }
+      }
     }
   }
 }

--- a/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
+++ b/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
@@ -12,6 +12,7 @@ import com.theoplayer.android.api.pip.PipConfiguration
 import com.theoplayer.android.api.player.NetworkConfiguration
 import com.theoplayer.android.api.ui.UIConfiguration
 import com.theoplayer.media.MediaSessionConfig
+import com.theoplayer.media.MediaSessionConfigAdapter
 
 private const val PROP_LICENSE = "license"
 private const val PROP_LICENSE_URL = "licenseUrl"
@@ -28,9 +29,8 @@ private const val PROP_RETRY_MAX_BACKOFF = "maximumBackoff"
 private const val PROP_CAST_CONFIGURATION = "cast"
 private const val PROP_ADS_CONFIGURATION = "ads"
 private const val PROP_UI_CONFIGURATION = "ui"
-private const val PROP_MEDIASESSION_ENABLED = "mediaSessionEnabled"
-private const val PROP_SKIP_FORWARD_INTERVAL = "skipForwardInterval"
-private const val PROP_SKIP_BACKWARD_INTERVAL = "skipBackwardInterval"
+private const val PROP_MEDIA_CONTROL = "mediaControl"
+
 
 class PlayerConfigAdapter(private val configProps: ReadableMap?) {
 
@@ -166,18 +166,6 @@ class PlayerConfigAdapter(private val configProps: ReadableMap?) {
    * - skipBackwardInterval: the amount of seconds the player will skip backward.
    */
   fun mediaSessionConfig(): MediaSessionConfig {
-    return MediaSessionConfig().apply {
-      configProps?.run {
-        if (hasKey(PROP_MEDIASESSION_ENABLED)) {
-          mediaSessionEnabled = getBoolean(PROP_MEDIASESSION_ENABLED)
-        }
-        if (hasKey(PROP_SKIP_FORWARD_INTERVAL)) {
-          skipForwardInterval = getDouble(PROP_SKIP_FORWARD_INTERVAL)
-        }
-        if (hasKey(PROP_SKIP_BACKWARD_INTERVAL)) {
-          skipBackwardInterval = getDouble(PROP_SKIP_BACKWARD_INTERVAL)
-        }
-      }
-    }
+    return MediaSessionConfigAdapter.fromProps(configProps?.getMap(PROP_MEDIA_CONTROL))
   }
 }

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -62,6 +62,12 @@ class ReactTHEOplayerContext private constructor(
       field = value
     }
 
+  var mediaSessionConfig: MediaSessionConfig = configAdapter.mediaSessionConfig()
+    set(value) {
+      applyMediaSessionConfig(mediaSessionConnector, value)
+      field = value
+    }
+
   lateinit var playerView: THEOplayerView
 
   val player: Player
@@ -99,7 +105,7 @@ class ReactTHEOplayerContext private constructor(
 
       // Get media session connector from service
       mediaSessionConnector = binder?.mediaSessionConnector?.also {
-        applyMediaSessionConfig(it, configAdapter.mediaSessionConfig())
+        applyMediaSessionConfig(it, mediaSessionConfig)
       }
 
       // Pass player context
@@ -232,12 +238,12 @@ class ReactTHEOplayerContext private constructor(
 
     // Create a MediaSessionConnector and attach the THEOplayer instance.
     mediaSessionConnector = MediaSessionConnector(mediaSession).also {
-      applyMediaSessionConfig(it, configAdapter.mediaSessionConfig())
+      applyMediaSessionConfig(it, mediaSessionConfig)
     }
   }
 
-  private fun applyMediaSessionConfig(connector: MediaSessionConnector, config: MediaSessionConfig) {
-    connector.apply {
+  private fun applyMediaSessionConfig(connector: MediaSessionConnector?, config: MediaSessionConfig) {
+    connector?.apply {
       debug = BuildConfig.LOG_MEDIASESSION_EVENTS
 
       player = this@ReactTHEOplayerContext.player

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -235,7 +235,7 @@ class ReactTHEOplayerContext private constructor(
 
       // Set mediaSession active and ready to receive media button events, but not if the player
       // is backgrounded.
-      setActive(!isHostPaused)
+      setActive(!isHostPaused && BuildConfig.EXTENSION_MEDIASESSION)
     }
   }
 
@@ -357,7 +357,7 @@ class ReactTHEOplayerContext private constructor(
    */
   fun onHostResume() {
     isHostPaused = false
-    mediaSessionConnector?.setActive(true)
+    mediaSessionConnector?.setActive(BuildConfig.EXTENSION_MEDIASESSION)
     playerView.onResume()
     if (!player.isPaused) {
       audioFocusManager?.retrieveAudioFocus()

--- a/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
@@ -173,7 +173,7 @@ class MediaPlaybackService : MediaBrowserServiceCompat() {
       debug = BuildConfig.LOG_MEDIASESSION_EVENTS
 
       // Set mediaSession active
-      setActive(true)
+      setActive(BuildConfig.EXTENSION_MEDIASESSION)
     }
 
     // Set the MediaBrowserServiceCompat's media session.

--- a/android/src/main/java/com/theoplayer/media/MediaSessionConfig.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaSessionConfig.kt
@@ -1,0 +1,18 @@
+package com.theoplayer.media
+
+class MediaSessionConfig {
+  /**
+   * Whether or not the media session should be enabled.
+   */
+  var mediaSessionEnabled: Boolean = true
+
+  /**
+   * The amount of seconds the player will skip forward.
+   */
+  var skipForwardInterval: Double = 5.0
+
+  /**
+   * The amount of seconds the player will skip backward.
+   */
+  var skipBackwardInterval: Double = 5.0
+}

--- a/android/src/main/java/com/theoplayer/media/MediaSessionConfig.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaSessionConfig.kt
@@ -1,18 +1,18 @@
 package com.theoplayer.media
 
-class MediaSessionConfig {
+data class MediaSessionConfig (
   /**
    * Whether or not the media session should be enabled.
    */
-  var mediaSessionEnabled: Boolean = true
+  var mediaSessionEnabled: Boolean = true,
 
   /**
    * The amount of seconds the player will skip forward.
    */
-  var skipForwardInterval: Double = 5.0
+  var skipForwardInterval: Double = 5.0,
 
   /**
    * The amount of seconds the player will skip backward.
    */
-  var skipBackwardInterval: Double = 5.0
-}
+  var skipBackwardInterval: Double = 5.0,
+)

--- a/android/src/main/java/com/theoplayer/media/MediaSessionConfigAdapter.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaSessionConfigAdapter.kt
@@ -1,0 +1,23 @@
+package com.theoplayer.media
+
+import com.facebook.react.bridge.ReadableMap
+
+object MediaSessionConfigAdapter {
+  private const val PROP_ENABLED = "mediaSessionEnabled"
+  private const val PROP_SKIP_FORWARD_INTERVAL = "skipForwardInterval"
+  private const val PROP_SKIP_BACKWARD_INTERVAL = "skipBackwardInterval"
+
+  fun fromProps(props: ReadableMap?): MediaSessionConfig {
+    return MediaSessionConfig().apply {
+      if (props?.hasKey(PROP_ENABLED) == true) {
+        mediaSessionEnabled = props.getBoolean(PROP_ENABLED)
+      }
+      if (props?.hasKey(PROP_SKIP_FORWARD_INTERVAL) == true) {
+        skipForwardInterval = props.getDouble(PROP_SKIP_FORWARD_INTERVAL)
+      }
+      if (props?.hasKey(PROP_SKIP_BACKWARD_INTERVAL) == true) {
+        skipBackwardInterval = props.getDouble(PROP_SKIP_BACKWARD_INTERVAL)
+      }
+    }
+  }
+}

--- a/src/api/media/MediaControlConfiguration.ts
+++ b/src/api/media/MediaControlConfiguration.ts
@@ -20,7 +20,27 @@ export interface MediaControlConfiguration {
    * @defaultValue `true`
    *
    * @remarks
-   * <br/> - This only applies to Web.
+   * <br/> - This property only applies to Web and Android.
    */
   readonly mediaSessionEnabled?: boolean;
+
+  /**
+   * The amount of seconds the player will skip forward.
+   *
+   * @defaultValue 5
+   *
+   * @remarks
+   * <br/> - This property only applies to Web and Android.
+   */
+  readonly skipForwardInterval?: number;
+
+  /**
+   * The amount of seconds the player will skip backward.
+   *
+   * @defaultValue 5
+   *
+   * @remarks
+   * <br/> - This property only applies to Web and Android.
+   */
+  readonly skipBackwardInterval?: number;
 }

--- a/src/internal/adapter/THEOplayerWebAdapter.ts
+++ b/src/internal/adapter/THEOplayerWebAdapter.ts
@@ -58,7 +58,7 @@ export class THEOplayerWebAdapter extends DefaultEventDispatcher<PlayerEventMap>
 
     // Optionally create a media session connector
     if (config?.mediaControl?.mediaSessionEnabled !== false) {
-      this._mediaSession = new WebMediaSession(this, player);
+      this._mediaSession = new WebMediaSession(this, player, config?.mediaControl);
     }
   }
 

--- a/src/internal/adapter/web/WebMediaSession.ts
+++ b/src/internal/adapter/web/WebMediaSession.ts
@@ -1,13 +1,15 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import type { ChromelessPlayer } from 'theoplayer';
 import type { THEOplayerWebAdapter } from '../THEOplayerWebAdapter';
+import { MediaControlConfiguration } from 'react-native-theoplayer';
 
-interface WebMediaSessionConfig {
-  skipTime: number;
-}
+const DEFAULT_SKIP_FORWARD_INTERVAL = 5;
+const DEFAULT_SKIP_BACKWARD_INTERVAL = 5;
 
-export const defaultWebMediaSessionConfig: WebMediaSessionConfig = {
-  skipTime: 15,
+export const defaultMediaControlConfiguration: MediaControlConfiguration = {
+  mediaSessionEnabled: true,
+  skipForwardInterval: DEFAULT_SKIP_FORWARD_INTERVAL,
+  skipBackwardInterval: DEFAULT_SKIP_BACKWARD_INTERVAL,
 };
 
 const NoOp = () => {};
@@ -28,11 +30,11 @@ const mediaSession = (function () {
  * @link https://w3c.github.io/mediasession
  */
 export class WebMediaSession {
-  private readonly _config: WebMediaSessionConfig;
+  private readonly _config: MediaControlConfiguration;
   private readonly _player: ChromelessPlayer;
   private readonly _webAdapter: THEOplayerWebAdapter;
 
-  constructor(adapter: THEOplayerWebAdapter, player: ChromelessPlayer, config: WebMediaSessionConfig = defaultWebMediaSessionConfig) {
+  constructor(adapter: THEOplayerWebAdapter, player: ChromelessPlayer, config: MediaControlConfiguration = defaultMediaControlConfiguration) {
     this._player = player;
     this._webAdapter = adapter;
     this._config = config;
@@ -48,11 +50,11 @@ export class WebMediaSession {
   updateActionHandlers() {
     if (this.isTrickplayEnabled()) {
       mediaSession.setActionHandler('seekbackward', (event) => {
-        const skipTime = event.seekOffset || this._config.skipTime;
+        const skipTime = event.seekOffset || this._config.skipBackwardInterval || DEFAULT_SKIP_BACKWARD_INTERVAL;
         this._player.currentTime = Math.max(this._player.currentTime - skipTime, 0);
       });
       mediaSession.setActionHandler('seekforward', (event) => {
-        const skipTime = event.seekOffset || this._config.skipTime;
+        const skipTime = event.seekOffset || this._config.skipForwardInterval || DEFAULT_SKIP_FORWARD_INTERVAL;
         this._player.currentTime = Math.min(this._player.currentTime + skipTime, this._player.duration);
       });
     } else {


### PR DESCRIPTION
Instead of having fixed skipForward/Backward intervals on Android and Web's media sessions, they can be configured in the 'mediaControl` property of `PlayerConfiguration`.