### PR TITLE
Feature/web optimize texttracks

### DIFF
--- a/src/internal/adapter/DefaultNativePlayerState.ts
+++ b/src/internal/adapter/DefaultNativePlayerState.ts
@@ -1,0 +1,42 @@
+import { DefaultTextTrackState } from './DefaultTextTrackState';
+import type { NativePlayerState } from './NativePlayerState';
+import {
+  AspectRatio,
+  BackgroundAudioConfiguration,
+  type MediaTrack,
+  PiPConfiguration,
+  PreloadType,
+  PresentationMode,
+  SourceDescription, TimeRange,
+} from 'react-native-theoplayer';
+
+export class DefaultNativePlayerState extends DefaultTextTrackState implements NativePlayerState {
+  source: SourceDescription | undefined = undefined;
+  autoplay = false;
+  paused = true;
+  seekable: TimeRange[] = [];
+  buffered: TimeRange[] = [];
+  pipConfig: PiPConfiguration = { startsAutomatically: false };
+  backgroundAudioConfig: BackgroundAudioConfiguration = { enabled: false };
+  presentationMode: PresentationMode = PresentationMode.inline;
+  muted = false;
+  seeking = false;
+  volume = 1;
+  currentTime = 0;
+  duration = 0;
+  playbackRate = 1;
+  preload: PreloadType = 'none';
+  aspectRatio: AspectRatio = AspectRatio.FIT;
+  keepScreenOn = true;
+  audioTracks: MediaTrack[] = [];
+  videoTracks: MediaTrack[] = [];
+  targetVideoQuality: number | number[] | undefined = undefined;
+  selectedAudioTrack: number | undefined = undefined;
+  selectedVideoTrack: number | undefined = undefined;
+  width: number | undefined = undefined;
+  height: number | undefined = undefined;
+
+  apply(state: Partial<NativePlayerState>): void {
+    Object.assign(this, state);
+  }
+}

--- a/src/internal/adapter/DefaultTextTrackState.ts
+++ b/src/internal/adapter/DefaultTextTrackState.ts
@@ -36,6 +36,10 @@ export class DefaultTextTrackState implements TextTrackState {
     return this._textTracks;
   }
 
+  set textTracks(tracks: TextTrack[]) {
+    this._textTracks = tracks;
+  }
+
   private onLoadedMetadata = (event: LoadedMetadataEvent) => {
     this._textTracks = event.textTracks;
     this._selectedTextTrack = event.selectedTextTrack;

--- a/src/internal/adapter/DefaultTextTrackState.ts
+++ b/src/internal/adapter/DefaultTextTrackState.ts
@@ -1,0 +1,94 @@
+import {
+  addTextTrackCue,
+  addTrack,
+  findTextTrackByUid, type LoadedMetadataEvent,
+  PlayerEventType,
+  removeTextTrackCue,
+  removeTrack,
+  TextTrack,
+  type TextTrackEvent,
+  TextTrackEventType,
+  type TextTrackListEvent,
+  TextTrackMode,
+  THEOplayer,
+  TrackListEventType,
+} from 'react-native-theoplayer';
+import { TextTrackState } from './NativePlayerState';
+
+export class DefaultTextTrackState implements TextTrackState {
+
+  private _textTracks: TextTrack[] = [];
+  private _selectedTextTrack: number | undefined;
+
+  constructor(private _player: THEOplayer) {
+    _player.addEventListener(PlayerEventType.LOADED_METADATA, this.onLoadedMetadata);
+    _player.addEventListener(PlayerEventType.TEXT_TRACK, this.onTextTrack);
+    _player.addEventListener(PlayerEventType.TEXT_TRACK_LIST, this.onTextTrackList);
+  }
+
+  destroy() {
+    this._player.removeEventListener(PlayerEventType.LOADED_METADATA, this.onLoadedMetadata);
+    this._player.removeEventListener(PlayerEventType.TEXT_TRACK, this.onTextTrack);
+    this._player.removeEventListener(PlayerEventType.TEXT_TRACK_LIST, this.onTextTrackList);
+  }
+
+  get textTracks(): TextTrack[] {
+    return this._textTracks;
+  }
+
+  private onLoadedMetadata = (event: LoadedMetadataEvent) => {
+    this._textTracks = event.textTracks;
+    this._selectedTextTrack = event.selectedTextTrack;
+  };
+
+  private onTextTrack = (event: TextTrackEvent) => {
+    const { subType, cue, trackUid } = event;
+    const track = findTextTrackByUid(this.textTracks, trackUid);
+    switch (subType) {
+      case TextTrackEventType.ADD_CUE:
+        addTextTrackCue(track, cue);
+        break;
+      case TextTrackEventType.REMOVE_CUE:
+        removeTextTrackCue(track, cue);
+        break;
+    }
+  };
+
+  private onTextTrackList = (event: TextTrackListEvent) => {
+    const { subType, track } = event;
+    switch (subType) {
+      case TrackListEventType.ADD_TRACK:
+        this._textTracks = addTrack(this._textTracks, track);
+        break;
+      case TrackListEventType.REMOVE_TRACK:
+        this._textTracks = removeTrack(this._textTracks, track);
+        break;
+      case TrackListEventType.CHANGE_TRACK:
+        this._textTracks = removeTrack(this._textTracks, track);
+        this._textTracks = addTrack(this._textTracks, track);
+        break;
+    }
+  };
+
+  get selectedTextTrack(): number | undefined {
+    return this._selectedTextTrack;
+  }
+
+  set selectedTextTrack(trackUid: number | undefined) {
+    if (!this.hasValidSource()) {
+      return;
+    }
+    this._selectedTextTrack = trackUid;
+    this.textTracks.forEach((track) => {
+      if (track.uid === trackUid) {
+        track.mode = TextTrackMode.showing;
+      } else if (track.mode === TextTrackMode.showing) {
+        track.mode = TextTrackMode.disabled;
+      }
+    });
+  }
+
+  private hasValidSource(): boolean {
+    return this._player?.source !== undefined;
+  }
+}

--- a/src/internal/adapter/NativePlayerState.ts
+++ b/src/internal/adapter/NativePlayerState.ts
@@ -1,31 +1,43 @@
-import type { MediaTrack, PreloadType, PresentationMode, SourceDescription, TextTrack, TimeRange } from 'react-native-theoplayer';
+import { MediaTrack, PreloadType, PresentationMode, SourceDescription, TextTrack, TimeRange } from 'react-native-theoplayer';
 import type { PiPConfiguration, AspectRatio, BackgroundAudioConfiguration } from 'react-native-theoplayer';
 
-export interface NativePlayerState {
+export interface PlayerConfigState {
   source: SourceDescription | undefined;
   autoplay: boolean;
-  paused: boolean;
-  seekable: TimeRange[] | undefined;
-  buffered: TimeRange[] | undefined;
   pipConfig: PiPConfiguration;
   backgroundAudioConfig: BackgroundAudioConfiguration;
-  presentationMode: PresentationMode;
+  preload: PreloadType;
+  keepScreenOn: boolean;
+  width: number | undefined;
+  height: number | undefined;
+}
+
+export interface PlaybackState {
+  paused: boolean;
   muted: boolean;
   seeking: boolean;
   volume: number;
   currentTime: number;
   duration: number;
   playbackRate: number;
-  preload: PreloadType;
+  seekable: TimeRange[];
+  buffered: TimeRange[];
+  presentationMode: PresentationMode;
   aspectRatio: AspectRatio;
-  keepScreenOn: boolean;
+}
+
+export interface MediaTrackState {
   audioTracks: MediaTrack[];
   videoTracks: MediaTrack[];
-  textTracks: TextTrack[];
   targetVideoQuality: number | number[] | undefined;
   selectedVideoTrack: number | undefined;
   selectedAudioTrack: number | undefined;
+}
+
+export interface TextTrackState {
+  textTracks: TextTrack[];
   selectedTextTrack: number | undefined;
-  width: number | undefined;
-  height: number | undefined;
+}
+
+export interface NativePlayerState extends PlayerConfigState, PlaybackState, TextTrackState, MediaTrackState {
 }

--- a/src/internal/adapter/THEOplayerAdapter.ts
+++ b/src/internal/adapter/THEOplayerAdapter.ts
@@ -18,29 +18,22 @@ import type {
   ResizeEvent,
   SourceDescription,
   TextTrack,
-  TextTrackEvent,
-  TextTrackListEvent,
   THEOplayer,
   THEOplayerView,
   TimeUpdateEvent,
 } from 'react-native-theoplayer';
 import {
-  addTextTrackCue,
   addTrack,
   AspectRatio,
   BackgroundAudioConfiguration,
   findMediaTrackByUid,
-  findTextTrackByUid,
   MediaTrackEventType,
   MediaTrackType,
   PlayerEventType,
   PlayerVersion,
   PreloadType,
   PresentationMode,
-  removeTextTrackCue,
   removeTrack,
-  TextTrackEventType,
-  TextTrackMode,
   TextTrackStyle,
   TrackListEventType,
 } from 'react-native-theoplayer';
@@ -51,37 +44,36 @@ import { NativeModules, Platform, StatusBar } from 'react-native';
 import { TextTrackStyleAdapter } from './track/TextTrackStyleAdapter';
 import type { NativePlayerState } from './NativePlayerState';
 import { EventBroadcastAdapter } from './broadcast/EventBroadcastAdapter';
+import { DefaultTextTrackState } from './DefaultTextTrackState';
 
 const NativePlayerModule = NativeModules.THEORCTPlayerModule;
 
-const defaultPlayerState: NativePlayerState = {
-  source: undefined,
-  autoplay: false,
-  paused: true,
-  seekable: [],
-  buffered: [],
-  pipConfig: { startsAutomatically: false },
-  backgroundAudioConfig: { enabled: false },
-  presentationMode: PresentationMode.inline,
-  muted: false,
-  seeking: false,
-  volume: 1,
-  currentTime: 0,
-  duration: NaN,
-  playbackRate: 1,
-  preload: 'none',
-  aspectRatio: AspectRatio.FIT,
-  keepScreenOn: true,
-  audioTracks: [],
-  videoTracks: [],
-  textTracks: [],
-  targetVideoQuality: undefined,
-  selectedVideoTrack: undefined,
-  selectedAudioTrack: undefined,
-  selectedTextTrack: undefined,
-  width: undefined,
-  height: undefined,
-};
+class DefaultNativePlayerState extends DefaultTextTrackState implements NativePlayerState {
+  source = undefined;
+  autoplay = false;
+  paused = true;
+  seekable = [];
+  buffered = [];
+  pipConfig: PiPConfiguration = { startsAutomatically: false };
+  backgroundAudioConfig: BackgroundAudioConfiguration = { enabled: false };
+  presentationMode: PresentationMode = PresentationMode.inline;
+  muted = false;
+  seeking = false;
+  volume = 1;
+  currentTime = 0;
+  duration = 0;
+  playbackRate = 1;
+  preload: PreloadType = 'none';
+  aspectRatio: AspectRatio = AspectRatio.FIT;
+  keepScreenOn = true;
+  audioTracks: MediaTrack[] = [];
+  videoTracks = [];
+  targetVideoQuality = undefined;
+  selectedAudioTrack = undefined;
+  selectedVideoTrack = undefined;
+  width = undefined;
+  height = undefined;
+}
 
 export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> implements THEOplayer {
   private readonly _view: THEOplayerView;
@@ -93,10 +85,10 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   private _externalEventRouter: EventBroadcastAPI | undefined = undefined;
   private _playerVersion!: PlayerVersion;
 
-  constructor(view: THEOplayerView, initialState: NativePlayerState = defaultPlayerState) {
+  constructor(view: THEOplayerView) {
     super();
     this._view = view;
-    this._state = { ...initialState };
+    this._state = new DefaultNativePlayerState(this);
     this._adsAdapter = new THEOplayerNativeAdsAdapter(this._view);
     this._castAdapter = new THEOplayerNativeCastAdapter(this, this._view);
     this._abrAdapter = new AbrAdapter(this._view);
@@ -112,8 +104,6 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
     this.addEventListener(PlayerEventType.SEEKING, this.onSeeking);
     this.addEventListener(PlayerEventType.SEEKED, this.onSeeked);
     this.addEventListener(PlayerEventType.PROGRESS, this.onProgress);
-    this.addEventListener(PlayerEventType.TEXT_TRACK_LIST, this.onTextTrackList);
-    this.addEventListener(PlayerEventType.TEXT_TRACK, this.onTextTrack);
     this.addEventListener(PlayerEventType.MEDIA_TRACK, this.onMediaTrack);
     this.addEventListener(PlayerEventType.MEDIA_TRACK_LIST, this.onMediaTrackList);
     this.addEventListener(PlayerEventType.PRESENTATIONMODE_CHANGE, this.onPresentationModeChange);
@@ -156,10 +146,8 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
     this._state.duration = event.duration;
     this._state.audioTracks = event.audioTracks;
     this._state.videoTracks = event.videoTracks;
-    this._state.textTracks = event.textTracks;
     this._state.selectedAudioTrack = event.selectedAudioTrack;
     this._state.selectedVideoTrack = event.selectedVideoTrack;
-    this._state.selectedTextTrack = event.selectedTextTrack;
     if (isFinite(this._state.duration)) {
       this._state.seekable = [{ start: 0, end: this._state.duration }];
     }
@@ -184,35 +172,6 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   private onProgress = (event: ProgressEvent) => {
     this._state.seekable = event.seekable?.sort((a, b) => a.end - b.end);
     this._state.buffered = event.buffered?.sort((a, b) => a.end - b.end);
-  };
-
-  private onTextTrack = (event: TextTrackEvent) => {
-    const { subType, cue, trackUid } = event;
-    const track = findTextTrackByUid(this._state.textTracks, trackUid);
-    switch (subType) {
-      case TextTrackEventType.ADD_CUE:
-        addTextTrackCue(track, cue);
-        break;
-      case TextTrackEventType.REMOVE_CUE:
-        removeTextTrackCue(track, cue);
-        break;
-    }
-  };
-
-  private onTextTrackList = (event: TextTrackListEvent) => {
-    const { subType, track } = event;
-    switch (subType) {
-      case TrackListEventType.ADD_TRACK:
-        this._state.textTracks = addTrack(this._state.textTracks, track);
-        break;
-      case TrackListEventType.REMOVE_TRACK:
-        this._state.textTracks = removeTrack(this._state.textTracks, track);
-        break;
-      case TrackListEventType.CHANGE_TRACK:
-        this._state.textTracks = removeTrack(this._state.textTracks, track);
-        this._state.textTracks = addTrack(this._state.textTracks, track);
-        break;
-    }
   };
 
   private onMediaTrack = (event: MediaTrackEvent) => {
@@ -442,17 +401,9 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   }
 
   set selectedTextTrack(trackUid: number | undefined) {
-    if (!this.hasValidSource()) {
-      return;
-    }
     this._state.selectedTextTrack = trackUid;
-    this.textTracks.forEach((track) => {
-      if (track.uid === trackUid) {
-        track.mode = TextTrackMode.showing;
-      } else if (track.mode === TextTrackMode.showing) {
-        track.mode = TextTrackMode.disabled;
-      }
-    });
+
+    // Apply native selection
     NativePlayerModule.setSelectedTextTrack(this._view.nativeHandle, trackUid !== undefined ? trackUid : -1);
   }
 


### PR DESCRIPTION
For web: instead of always rebuilding the RN text track model when querying the text tracks list through the API, use a shared text track state between web and mobile platforms and keep it up-to-date using events.