### PR TITLE
Fix/Android TV: disable remote controls rw/ff for live

### DIFF
--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -155,10 +155,12 @@ class ReactTHEOplayerContext private constructor(
     // Reduce allowed set of remote control playback actions for ads & live streams.
     val isLive = player.duration.isInfinite()
     val isInAd = player.ads.isPlaying
-    mediaSessionConnector?.enabledPlaybackActions = if (isInAd || isLive && !isTV) {
-      0
-    } else {
-      ALLOWED_PLAYBACK_ACTIONS
+    mediaSessionConnector?.enabledPlaybackActions = when {
+      isInAd || isLive && !isTV -> 0
+      isLive && isTV -> ALLOWED_PLAYBACK_ACTIONS xor
+        PlaybackStateCompat.ACTION_FAST_FORWARD xor
+        PlaybackStateCompat.ACTION_REWIND
+      else -> ALLOWED_PLAYBACK_ACTIONS
     }
   }
 

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerView.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerView.kt
@@ -53,23 +53,22 @@ class ReactTHEOplayerView(private val reactContext: ThemedReactContext) :
     playerContext = ReactTHEOplayerContext.create(
       reactContext,
       PlayerConfigAdapter(configProps)
-    )
-    playerContext?.let {
+    ).apply {
       if (BuildConfig.EXTENSION_ADS) {
-        adsApi.initialize(it.player, it.imaIntegration, it.daiIntegration)
+        adsApi.initialize(player, imaIntegration, daiIntegration)
       }
       val layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
-      it.playerView.layoutParams = layoutParams
-      (it.playerView.parent as? ViewGroup)?.removeView(it.playerView)
-      addView(it.playerView, 0, layoutParams)
+      playerView.layoutParams = layoutParams
+      (playerView.parent as? ViewGroup)?.removeView(playerView)
+      addView(playerView, 0, layoutParams)
 
       presentationManager = PresentationManager(
-        it,
+        this,
         reactContext,
         eventEmitter
       )
 
-      eventEmitter.preparePlayer(it.player)
+      eventEmitter.preparePlayer(player)
     }
   }
 


### PR DESCRIPTION
**Summary:**
This PR disables "skip forward/rewind" on remote control for live on Android TV as pressing it makes player buffering live content. Also adds minor improvements to the Kt codebase

**Test-Plan:**

1. Run test app on Android TV
2. Watch live stream
3. Press the fast forward or rewind button on the remote control.

Expected: it continues playback, doesn't reloads/show spinner, doesn't stop playback
Before the fix: it buffers content but doesn't actually seek