### PR TITLE
Release/v7.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,7 +72,7 @@ ios/build.sh
 ios/custom/Frameworks/tvos/*.xcframework
 
 # TypeDoc
-api/
+/api/
 
 # Jekyll / GitHub Pages
 _site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.4.0] - 24-06-11
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added support for `SourceDescription.poster` for Android & iOS.
+
 ## [7.3.0] - 24-06-03
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added support for `SourceDescription.poster` for Android & iOS.
+- Made the intervals for the forward and backward skip buttons on the iOS lockScreen configurable.
 
 ## [7.3.0] - 24-06-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added support for `SourceDescription.poster` for Android & iOS.
 - Made the intervals for the forward and backward skip buttons on the iOS lockScreen configurable.
+- Added preferredPeakBitRate and preferredMaximumResolution to ABRConfiguration for iOS
 
 ## [7.3.0] - 24-06-03
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -953,7 +953,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - react-native-theoplayer (7.2.0):
+  - react-native-theoplayer (7.3.0):
     - google-cast-sdk-dynamic-xcframework (~> 4.8)
     - React-Core
     - THEOplayer-Connector-SideloadedSubtitle (~> 7.4)
@@ -1441,7 +1441,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: e1da272870606f17a64520bf78d85e1b73bb0778
   react-native-google-cast: d7bdfd1a0eeba84afde03b9722351ec29543e74c
   react-native-slider: ce295d2bf830a7990af05b0bd70ab28c133e230c
-  react-native-theoplayer: b4a04831875771f6a638a9f0d92fee034d6892dd
+  react-native-theoplayer: eb0262741ef73b9693ba775a38f8c2d5cdf2bb24
   React-nativeconfig: 0e309fafbbfbb8eac2f1999d0756732624ac5b39
   React-NativeModulesApple: a53141b07c57c53cdc1f2043e5acf3b9318bc340
   React-perflogger: e4f171200bc71bb8cf0686a0ad41a242f53b6b36

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -51,6 +51,8 @@ const playerConfig: PlayerConfiguration = {
   },
   mediaControl: {
     mediaSessionEnabled: true,
+    skipForwardInterval: 30,
+    skipBackwardInterval: 10,
   },
 };
 

--- a/example/src/custom/sources.json
+++ b/example/src/custom/sources.json
@@ -241,7 +241,7 @@
         "src": "https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8",
         "type": "application/x-mpegurl"
       },
-      "poster": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-1200x1200.png",
+      "poster": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-1200x675.png",
       "metadata": {
         "title": "Bipbop",
         "subtitle": "Bipbop Subtitle",
@@ -262,7 +262,7 @@
         "src": "https://cdn.theoplayer.com/video/elephants-dream/playlist-single-audio.m3u8",
         "type": "application/x-mpegurl"
       },
-      "poster": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-1200x1200.png",
+      "poster": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-1200x675.png",
       "metadata": {
         "title": "Elephants Dream",
         "subtitle": "Elephants Dream Subtitle",
@@ -291,7 +291,7 @@
           "sources": "https://cdn.theoplayer.com/demos/ads/vast/dfp-preroll-no-skip.xml"
         }
       ],
-      "poster": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-1200x1200.png",
+      "poster": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-1200x675.png",
       "metadata": {
         "title": "Elephants Dream with Preroll",
         "subtitle": "Elephants Dream with Preroll Subtitle",
@@ -323,7 +323,7 @@
           "timeOffset": 10
         }
       ],
-      "poster": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-1200x1200.png",
+      "poster": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-1200x675.png",
       "metadata": {
         "title": "Elephants Dream with Midroll",
         "subtitle": "Elephants Dream with Midroll Subtitle",
@@ -354,7 +354,7 @@
           }
         }
       ],
-      "poster": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-1200x1200.png",
+      "poster": "https://theoplayer-cdn.s3.eu-west-1.amazonaws.com/react-native-theoplayer/temp/THEOPlayer-1200x675.png",
       "metadata": {
         "title": "Elephants Dream with VMAP",
         "subtitle": "Elephants Dream with VMAP Subtitle",

--- a/ios/THEOplayerRCTPlayerAPI.swift
+++ b/ios/THEOplayerRCTPlayerAPI.swift
@@ -10,7 +10,6 @@ import THEOplayerSDK
 import THEOplayerConnectorSideloadedSubtitle
 #endif
 
-let ERROR_MESSAGE_PLAYER_ABR_UNSUPPORTED_FEATURE: String = "Setting an ABRconfig is not supported on iOS/tvOS."
 let ERROR_MESSAGE_PLAYER_QUALITY_UNSUPPORTED_FEATURE: String = "Setting a target video quality is not supported on iOS/tvOS."
 
 let TTS_PROP_BACKGROUND_COLOR = "backgroundColor"
@@ -92,8 +91,34 @@ class THEOplayerRCTPlayerAPI: NSObject, RCTBridgeModule {
     }
 
     @objc(setABRConfig:abrConfig:)
-    func setABRConfig(_ node: NSNumber, setABRConfig: NSDictionary) -> Void {
-        if DEBUG_PLAYER_API { print(ERROR_MESSAGE_PLAYER_ABR_UNSUPPORTED_FEATURE) }
+    func setABRConfig(_ node: NSNumber, abrConfig: NSDictionary) -> Void {
+        DispatchQueue.main.async {
+            if let theView = self.bridge.uiManager.view(forReactTag: node) as? THEOplayerRCTView,
+               let player = theView.player {
+                if DEBUG_PLAYER_API { PrintUtils.printLog(logText: "[NATIVE] Setting abrConfig on TheoPlayer") }
+                if let configuredTargetBuffer = abrConfig["targetBuffer"] as? Double {
+                    player.abr.targetBuffer = configuredTargetBuffer
+                } else if let configuredTargetBuffer = abrConfig["targetBuffer"] as? Int {
+                    player.abr.targetBuffer = Double(configuredTargetBuffer)
+                }
+                if let configuredPreferredPeakBitRate = abrConfig["preferredPeakBitRate"] as? Double {
+                    player.abr.preferredPeakBitRate = configuredPreferredPeakBitRate
+                } else if let configuredPreferredPeakBitRate = abrConfig["preferredPeakBitRate"] as? Int {
+                    player.abr.preferredPeakBitRate = Double(configuredPreferredPeakBitRate)
+                }
+                if let configuredPreferredMaximumResolution = abrConfig["preferredMaximumResolution"] as? [String:Double] {
+                    if let width = configuredPreferredMaximumResolution["width"],
+                       let height = configuredPreferredMaximumResolution["height"] {
+                        player.abr.preferredMaximumResolution = CGSize(width: width, height: height)
+                    }
+                } else if let configuredPreferredMaximumResolution = abrConfig["preferredMaximumResolution"] as? [String:Int] {
+                    if let width = configuredPreferredMaximumResolution["width"],
+                       let height = configuredPreferredMaximumResolution["height"] {
+                        player.abr.preferredMaximumResolution = CGSize(width: Double(width), height: Double(height))
+                    }
+                }
+            }
+        }
     }
 
     @objc(setCurrentTime:time:)

--- a/ios/THEOplayerRCTView.swift
+++ b/ios/THEOplayerRCTView.swift
@@ -18,10 +18,16 @@ public class THEOplayerRCTView: UIView {
     var nowPlayingManager: THEOplayerRCTNowPlayingManager
     var remoteCommandsManager: THEOplayerRCTRemoteCommandsManager
     var pipControlsManager: THEOplayerRCTPipControlsManager
+    
     var adsConfig = AdsConfig()
     var castConfig = CastConfig()
     var uiConfig = UIConfig()
     
+    var mediaControlConfig = MediaControlConfig() {
+        didSet {
+            self.remoteCommandsManager.setMediaControlConfig(mediaControlConfig)
+        }
+    }
     var pipConfig = PipConfig() {
         didSet {
             self.pipControlsManager.setPipConfig(pipConfig)
@@ -161,6 +167,7 @@ public class THEOplayerRCTView: UIView {
         self.parseAdsConfig(configDict: configDict)
         self.parseCastConfig(configDict: configDict)
         self.parseUIConfig(configDict: configDict)
+        self.parseMediaControlConfig(configDict: configDict)
         if DEBUG_VIEW { PrintUtils.printLog(logText: "[NATIVE] config prop updated.") }
         
         // Given the bridged config, create the initial THEOplayer instance

--- a/ios/backgroundAudio/THEOplayerRCTRemoteCommandsManager.swift
+++ b/ios/backgroundAudio/THEOplayerRCTRemoteCommandsManager.swift
@@ -4,14 +4,13 @@ import Foundation
 import THEOplayerSDK
 import MediaPlayer
 
-let DEFAULT_SKIP_INTERVAL: UInt = 15
-
 class THEOplayerRCTRemoteCommandsManager: NSObject {
     // MARK: Members
     private weak var player: THEOplayer?
     private var isLive: Bool = false
     private var inAd: Bool = false
     private var backgroundaudioConfig = BackgroundAudioConfig()
+    private var mediaControlConfig = MediaControlConfig()
     
     // MARK: player Listeners
     private var durationChangeListener: EventListener?
@@ -39,6 +38,11 @@ class THEOplayerRCTRemoteCommandsManager: NSObject {
         self.updateRemoteCommands()
     }
     
+    func setMediaControlConfig(_ newMediaControlConfig: MediaControlConfig) {
+        self.mediaControlConfig = newMediaControlConfig
+        self.updateRemoteCommands()
+    }
+    
     private func initRemoteCommands() {
         self.isLive = false
         self.inAd = false
@@ -61,10 +65,10 @@ class THEOplayerRCTRemoteCommandsManager: NSObject {
         // SCRUBBER
         commandCenter.changePlaybackPositionCommand.addTarget(self, action: #selector(onScrubCommand(_:)))
         // ADD SEEK FORWARD
-        commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: DEFAULT_SKIP_INTERVAL)]
+        commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: self.mediaControlConfig.skipForwardInterval)]
         commandCenter.skipForwardCommand.addTarget(self, action: #selector(onSkipForwardCommand(_:)))
         // ADD SEEK BACKWARD
-        commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: DEFAULT_SKIP_INTERVAL)]
+        commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: self.mediaControlConfig.skipBackwardInterval)]
         commandCenter.skipBackwardCommand.addTarget(self, action: #selector(onSkipBackwardCommand(_:)))
         
         if DEBUG_REMOTECOMMANDS { PrintUtils.printLog(logText: "[NATIVE] Remote commands initialised.") }
@@ -81,6 +85,10 @@ class THEOplayerRCTRemoteCommandsManager: NSObject {
         commandCenter.changePlaybackPositionCommand.isEnabled = !self.isLive && !self.inAd && self.backgroundaudioConfig.enabled
         commandCenter.skipForwardCommand.isEnabled = !self.isLive && !self.inAd && self.backgroundaudioConfig.enabled
         commandCenter.skipBackwardCommand.isEnabled = !self.isLive && !self.inAd && self.backgroundaudioConfig.enabled
+        
+        // set configured skip forward/backward intervals
+        commandCenter.skipForwardCommand.preferredIntervals = [NSNumber(value: self.mediaControlConfig.skipForwardInterval)]
+        commandCenter.skipBackwardCommand.preferredIntervals = [NSNumber(value: self.mediaControlConfig.skipBackwardInterval)]
         
         if DEBUG_REMOTECOMMANDS { PrintUtils.printLog(logText: "[NATIVE] Remote commands updated for \(self.isLive ? "LIVE" : "VOD") (\(self.inAd ? "AD IS PLAYING" : "NO AD PLAYING"), \(self.backgroundaudioConfig.enabled ? "BGAUDIO ENABLED" : "BGAUDIO DISABLED") ).") }
     }

--- a/ios/backgroundAudio/THEOplayerRCTView+MediaControlConfig.swift
+++ b/ios/backgroundAudio/THEOplayerRCTView+MediaControlConfig.swift
@@ -1,0 +1,23 @@
+// THEOplayerRCTView+UIConfig.swift
+
+import Foundation
+import THEOplayerSDK
+
+struct MediaControlConfig {
+    var skipForwardInterval: Int = 15
+    var skipBackwardInterval: Int = 15
+}
+
+extension THEOplayerRCTView {
+    
+    func parseMediaControlConfig(configDict: NSDictionary) {
+        if let mediaControlConfig = configDict["mediaControl"] as? NSDictionary {
+            if let skipForwardInterval = mediaControlConfig["skipForwardInterval"] as? Int {
+                self.mediaControlConfig.skipForwardInterval = skipForwardInterval
+            }
+            if let skipBackwardInterval = mediaControlConfig["skipBackwardInterval"] as? Int {
+                self.mediaControlConfig.skipBackwardInterval = skipBackwardInterval
+            }
+        }
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-theoplayer",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-theoplayer",
-      "version": "7.3.0",
+      "version": "7.4.0",
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
       "dependencies": {
         "buffer": "^6.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-theoplayer",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "A THEOplayer video component for react-native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/api/abr/ABRConfiguration.ts
+++ b/src/api/abr/ABRConfiguration.ts
@@ -1,3 +1,5 @@
+import { Resolution } from '../resolution/Resolution';
+
 /**
  * The adaptive bitrate strategy of the first segment, represented by a value from the following list:
  * <br/> - `'performance'`: The player will optimize ABR behavior to focus on the performance of the player. This strategy initiates playback with the lowest quality suitable for the device which means faster start-up time.
@@ -62,6 +64,8 @@ export interface ABRConfiguration {
    * The adaptive bitrate strategy.
    *
    * @defaultValue `'bandwidth'`
+   * @remarks
+   * <br/> - This property is currently supported on Web and Android platforms only.
    */
   strategy?: ABRStrategy;
 
@@ -104,4 +108,26 @@ export interface ABRConfiguration {
    * <br/> - This property is currently supported on Web platforms only.
    */
   readonly maxBufferLength?: number;
+
+  /**
+   * The desired limit of network bandwidth consumption for this item.
+   *
+   * Set preferredPeakBitRate to non-zero to indicate that the player should attempt to limit item playback to that bit rate, expressed in bits per second.
+   * If network bandwidth consumption cannot be lowered to meet the preferredPeakBitRate, it will be reduced as much as possible while continuing to play the item.
+   *
+   * @remarks
+   * <br/> - This property is supported on iOS platforms only.
+   */
+  preferredPeakBitRate?: number;
+
+  /**
+   * A preferred upper limit on the resolution of the video to be downloaded (or otherwise transferred) and rendered by the player.
+   *
+   * The default value is (0,0), which indicates that the client enforces no limit on video resolution. Other values indicate a preferred maximum video resolution.
+   * It only applies to HTTP Live Streaming asset.
+   *
+   * @remarks
+   * <br/> - This property is supported on iOS platforms only.
+   */
+  preferredMaximumResolution?: Resolution;
 }

--- a/src/api/barrel.ts
+++ b/src/api/barrel.ts
@@ -12,6 +12,7 @@ export * from './media/barrel';
 export * from './drm/barrel';
 export * from './source/barrel';
 export * from './timeranges/barrel';
+export * from './resolution/barrel';
 export * from './track/barrel';
 export * from './ui/barrel';
 export * from './utils/barrel';

--- a/src/api/media/MediaControlConfiguration.ts
+++ b/src/api/media/MediaControlConfiguration.ts
@@ -27,20 +27,14 @@ export interface MediaControlConfiguration {
   /**
    * The amount of seconds the player will skip forward.
    *
-   * @defaultValue 5
-   *
-   * @remarks
-   * <br/> - This property only applies to Web and Android.
+   * @defaultValue 5 on Web and android, 15 on iOS.
    */
   readonly skipForwardInterval?: number;
 
   /**
    * The amount of seconds the player will skip backward.
    *
-   * @defaultValue 5
-   *
-   * @remarks
-   * <br/> - This property only applies to Web and Android.
+   * @defaultValue 5 on Web and android, 15 on iOS.
    */
   readonly skipBackwardInterval?: number;
 }

--- a/src/api/player/THEOplayer.ts
+++ b/src/api/player/THEOplayer.ts
@@ -12,7 +12,7 @@ import type { PresentationMode } from '../presentation/PresentationMode';
 import type { PiPConfiguration } from '../pip/PiPConfiguration';
 import type { BackgroundAudioConfiguration } from '../backgroundAudio/BackgroundAudioConfiguration';
 import type { PlayerVersion } from './PlayerVersion';
-import type { EventBroadcastAPI } from "../broadcast/EventBroadcastAPI";
+import type { EventBroadcastAPI } from '../broadcast/EventBroadcastAPI';
 
 export type PreloadType = 'none' | 'metadata' | 'auto' | '';
 
@@ -40,9 +40,6 @@ export type NativeHandleType = unknown;
 export interface THEOplayer extends EventDispatcher<PlayerEventMap> {
   /**
    * The player's adaptive bitrate (ABR) configuration.
-   *
-   * @remarks
-   * <br/> - This property is supported on Android & Web platforms only.
    */
   readonly abr: ABRConfiguration | undefined;
 

--- a/src/api/resolution/Resolution.ts
+++ b/src/api/resolution/Resolution.ts
@@ -1,0 +1,5 @@
+export interface Resolution {
+  readonly width: number;
+
+  readonly height: number;
+}

--- a/src/api/resolution/barrel.ts
+++ b/src/api/resolution/barrel.ts
@@ -1,0 +1,1 @@
+export * from './Resolution';

--- a/src/api/source/SourceDescription.ts
+++ b/src/api/source/SourceDescription.ts
@@ -60,7 +60,6 @@ export interface SourceConfiguration {
    *
    * @remarks
    * <br/> - An empty string (`''`) clears the current poster.
-   * <br/> - This poster has priority over {@link theoplayer!ChromelessPlayer.poster}.
    */
   poster?: string;
 

--- a/src/internal/THEOplayerView.tsx
+++ b/src/internal/THEOplayerView.tsx
@@ -65,6 +65,7 @@ import type {
 import type { NativeAdEvent } from './adapter/event/native/NativeAdEvent';
 import { THEOplayerAdapter } from './adapter/THEOplayerAdapter';
 import { getFullscreenSize } from './utils/Dimensions';
+import { Poster } from './poster/Poster';
 
 const INVALID_HANDLE = -1;
 
@@ -107,6 +108,8 @@ interface THEOplayerRCTViewState {
   error?: PlayerError;
   presentationMode?: PresentationMode | undefined;
   screenSize: ScaledSize;
+  posterActive: boolean;
+  poster: string | undefined;
 }
 
 type THEOplayerViewNativeComponent = HostComponent<THEOplayerRCTViewProps>;
@@ -120,6 +123,8 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
     error: undefined,
     presentationMode: PresentationMode.inline,
     screenSize: getFullscreenSize(),
+    posterActive: false,
+    poster: undefined,
   };
 
   constructor(props: THEOplayerViewProps) {
@@ -176,6 +181,8 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
   private _onSourceChange = () => {
     this.reset();
     this._facade.dispatchEvent(new BaseEvent(PlayerEventType.SOURCE_CHANGE));
+    this._updatePoster();
+    this._showPoster();
   };
 
   private _onLoadStart = () => {
@@ -221,6 +228,7 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
 
   private _onPlay = () => {
     this._facade.dispatchEvent(new BaseEvent(PlayerEventType.PLAY));
+    this._hidePoster();
   };
 
   private _onPlaying = () => {
@@ -352,9 +360,21 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
     this._facade.dispatchEvent(new DefaultResizeEvent(event.nativeEvent.width, event.nativeEvent.height));
   };
 
+  private _updatePoster = () => {
+    this.setState({ poster: this._facade.source?.poster });
+  };
+
+  private _showPoster = () => {
+    this.setState({ posterActive: true });
+  };
+
+  private _hidePoster = () => {
+    this.setState({ posterActive: false });
+  };
+
   public render(): JSX.Element {
     const { config, style, children } = this.props;
-    const { presentationMode, screenSize: fullscreenSize } = this.state;
+    const { presentationMode, screenSize: fullscreenSize, posterActive, poster } = this.state;
 
     return (
       <View style={[styles.base, style, presentationMode === PresentationMode.fullscreen ? fullscreenSize : {}]}>
@@ -392,6 +412,7 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
           onNativePresentationModeChange={this._onPresentationModeChange}
           onNativeResize={this._onResize}
         />
+        {posterActive && <Poster uri={poster} />}
         {children}
       </View>
     );

--- a/src/internal/adapter/THEOplayerAdapter.ts
+++ b/src/internal/adapter/THEOplayerAdapter.ts
@@ -198,7 +198,7 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   };
 
   get abr(): ABRConfiguration | undefined {
-    return Platform.OS === 'android' ? this._abrAdapter : undefined;
+    return this._abrAdapter;
   }
 
   get ads(): AdsAPI {

--- a/src/internal/adapter/abr/AbrAdapter.ts
+++ b/src/internal/adapter/abr/AbrAdapter.ts
@@ -1,4 +1,4 @@
-import type { ABRConfiguration, ABRStrategy, THEOplayerView } from 'react-native-theoplayer';
+import type { ABRConfiguration, ABRStrategy, Resolution, THEOplayerView } from 'react-native-theoplayer';
 import { NativeModules } from 'react-native';
 
 const NativePlayerModule = NativeModules.THEORCTPlayerModule;
@@ -7,6 +7,8 @@ export class AbrAdapter implements ABRConfiguration {
   private readonly _view: THEOplayerView;
   private _strategy: ABRStrategy | undefined;
   private _targetBuffer: number | undefined;
+  private _preferredPeakBitRate: number | undefined;
+  private _preferredMaximumResolution: Resolution | undefined;
 
   constructor(view: THEOplayerView) {
     this._view = view;
@@ -30,10 +32,30 @@ export class AbrAdapter implements ABRConfiguration {
     this.updateConfig();
   }
 
+  get preferredPeakBitRate(): number | undefined {
+    return this._preferredPeakBitRate;
+  }
+
+  set preferredPeakBitRate(preferredPeakBitRate: number | undefined) {
+    this._preferredPeakBitRate = preferredPeakBitRate;
+    this.updateConfig();
+  }
+
+  get preferredMaximumResolution(): Resolution | undefined {
+    return this._preferredMaximumResolution;
+  }
+
+  set preferredMaximumResolution(preferredMaximumResolution: Resolution | undefined) {
+    this._preferredMaximumResolution = preferredMaximumResolution;
+    this.updateConfig();
+  }
+
   private updateConfig() {
     NativePlayerModule.setABRConfig(this._view.nativeHandle, {
       targetBuffer: this._targetBuffer,
       strategy: this._strategy,
+      preferredPeakBitRate: this._preferredPeakBitRate,
+      preferredMaximumResolution: this._preferredMaximumResolution,
     });
   }
 }

--- a/src/internal/poster/Poster.tsx
+++ b/src/internal/poster/Poster.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Image, StyleSheet, View } from 'react-native';
+
+export const Poster = (props: { uri: string | undefined }) => {
+  const { uri } = props;
+  if (!uri) {
+    return <></>;
+  }
+  return (
+    <View style={[StyleSheet.absoluteFill, { justifyContent: 'center' }]}>
+      <Image style={{ aspectRatio: 16 / 9 }} source={{ uri }} />
+    </View>
+  );
+};


### PR DESCRIPTION
### Added

- Added support for `SourceDescription.poster` for Android & iOS.
- Made the intervals for the forward and backward skip buttons on the iOS lockScreen configurable.
- Added preferredPeakBitRate and preferredMaximumResolution to ABRConfiguration for iOS