### PR TITLE
await cast adapter initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Fixed an issue where the Cast API wouldn't be initialized yet when in the `onPlayerReady` callback.
+
 ## [7.4.0] - 24-06-11
 
 ### Added

--- a/src/internal/THEOplayerView.tsx
+++ b/src/internal/THEOplayerView.tsx
@@ -174,8 +174,9 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
   private _onNativePlayerReady = (event: NativeSyntheticEvent<NativePlayerStateEvent>) => {
     // Optionally apply an initial player state
     const { version, state } = event.nativeEvent;
-    this._facade.initializeFromNativePlayer_(version, state);
-    this.props.onPlayerReady?.(this._facade);
+    this._facade.initializeFromNativePlayer_(version, state).then(() => {
+      this.props.onPlayerReady?.(this._facade);
+    });
   };
 
   private _onSourceChange = () => {

--- a/src/internal/adapter/THEOplayerAdapter.ts
+++ b/src/internal/adapter/THEOplayerAdapter.ts
@@ -491,12 +491,12 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
    * @param version The native player version.
    * @param state An optional initial player state.
    */
-  initializeFromNativePlayer_(version: PlayerVersion, state: NativePlayerState | undefined) {
+  async initializeFromNativePlayer_(version: PlayerVersion, state: NativePlayerState | undefined) {
     this._playerVersion = version;
     if (state) {
       this._state.apply(state);
     }
-    this._castAdapter.init_();
+    await this._castAdapter.init_();
   }
 
   get width(): number | undefined {

--- a/src/internal/adapter/cast/THEOplayerNativeCastAdapter.ts
+++ b/src/internal/adapter/cast/THEOplayerNativeCastAdapter.ts
@@ -27,9 +27,9 @@ export class THEOplayerNativeCastAdapter implements CastAPI {
     return this._airplay;
   }
 
-  init_(): void {
-    void this._chromecast?.init_();
-    void this._airplay?.init_();
+  async init_(): Promise<void> {
+    await this._chromecast?.init_();
+    await this._airplay?.init_();
   }
 
   unload_(): void {


### PR DESCRIPTION
[Default values](https://github.com/THEOplayer/react-native-theoplayer/blob/develop/src/internal/adapter/cast/THEOplayerNativeAirplay.ts#L10-L11) would be returned for `player.cast.airplay.casting` (`false`) and `player.cast.airplay.state` (`CastState.available`) if requested before the initialization of the Cast API finished, even if the user is connected to an AirPlay device. This PR aims to resolve this by only calling the onPlayerReady callback once this initialization is done.