### PR TITLE
Initialize the cache API on the main thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed an issue where on iOS a cached asset would not play when setting the tasks's source on the player.
 - Fixed an issue where on iOS the createTask method (CacheAPI) was not returning the created task.
+- Fixed an issue where on Android the native module preparation would fail due to a change in the Android SDK 7.8.0 on eventDispatching.
 
 ## [7.6.0] - 24-07-01
 

--- a/android/src/main/java/com/theoplayer/cache/CacheModule.kt
+++ b/android/src/main/java/com/theoplayer/cache/CacheModule.kt
@@ -52,34 +52,36 @@ class CacheModule(private val context: ReactApplicationContext) :
 
   init {
     // Add cache event listeners
-    cache?.apply {
-      // Listen for cache state changes
-      addEventListener(CacheEventTypes.CACHE_STATE_CHANGE) { event ->
-        emit("onCacheStatusChange", Arguments.createMap().apply {
-          putString(PROP_STATUS, CacheAdapter.fromCacheStatus(event.status))
-        })
-      }
-      // Listen for add task events
-      tasks.addEventListener(CachingTaskListEventTypes.ADD_TASK) { event ->
-        event.task?.let { task ->
-          // Notify AddCachingTaskEvent event
-          emit("onAddCachingTaskEvent", Arguments.createMap().apply {
-            putMap(PROP_TASK, CacheAdapter.fromCachingTask(task))
+    handler.post {
+      cache?.apply {
+        // Listen for cache state changes
+        addEventListener(CacheEventTypes.CACHE_STATE_CHANGE) { event ->
+          emit("onCacheStatusChange", Arguments.createMap().apply {
+            putString(PROP_STATUS, CacheAdapter.fromCacheStatus(event.status))
           })
-          // Add CachingTask listeners
-          addCachingTaskListeners(task)
+       }
+        // Listen for add task events
+        tasks.addEventListener(CachingTaskListEventTypes.ADD_TASK) { event ->
+          event.task?.let { task ->
+            // Notify AddCachingTaskEvent event
+            emit("onAddCachingTaskEvent", Arguments.createMap().apply {
+              putMap(PROP_TASK, CacheAdapter.fromCachingTask(task))
+            })
+            // Add CachingTask listeners
+            addCachingTaskListeners(task)
+          }
         }
-      }
 
-      // Listen for task removal
-      tasks.addEventListener(CachingTaskListEventTypes.REMOVE_TASK) { event ->
-        event.task?.let { task ->
-          // Notify RemoveCachingTaskEvent event
-          emit("onRemoveCachingTaskEvent", Arguments.createMap().apply {
-            putMap(PROP_TASK, CacheAdapter.fromCachingTask(event.task))
-          })
-          // Remove CachingTask listeners
-          removeCachingTaskListeners(task)
+        // Listen for task removal
+        tasks.addEventListener(CachingTaskListEventTypes.REMOVE_TASK) { event ->
+          event.task?.let { task ->
+            // Notify RemoveCachingTaskEvent event
+            emit("onRemoveCachingTaskEvent", Arguments.createMap().apply {
+              putMap(PROP_TASK, CacheAdapter.fromCachingTask(event.task))
+            })
+            // Remove CachingTask listeners
+            removeCachingTaskListeners(task)
+          }
         }
       }
     }


### PR DESCRIPTION
Fixes the crash caused by the threading changes on the underlying Android SDK on 7.8.0.