### PR TITLE
Release/v7.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed an issue where on iOS a cached asset would not play when setting the tasks's source on the player.
 - Fixed an issue where on iOS the createTask method (CacheAPI) was not returning the created task.
 
 ## [7.6.0] - 24-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [7.7.0] - 24-07-25
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed an issue where on iOS a cached asset would not play when setting the tasks's source on the player.
 - Fixed an issue where on iOS the createTask method (CacheAPI) was not returning the created task.
+- Fixed an issue where on iOS the Ad and AdBreak protocols where extended in the underlying native SDK and required some modifications.
 - Fixed an issue where on Android the native module preparation would fail due to a change in the Android SDK 7.8.0 on eventDispatching.
 
 ## [7.6.0] - 24-07-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed an issue where on iOS a cached asset would not play when setting the tasks's source on the player.
 - Fixed an issue where on iOS the createTask method (CacheAPI) was not returning the created task.
+- Fixed an issue where on Android the native module preparation would fail due to a change in the Android SDK 7.8.0 on eventDispatching.
 
 ## [7.6.0] - 24-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added ActiveQualityChanged event support for iOS.
+
 ## [7.6.0] - 24-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added ActiveQualityChanged event support for iOS.
 
+### Fixed
+
+- Fixed an issue where on iOS the createTask method (CacheAPI) was not returning the created task.
+
 ## [7.6.0] - 24-07-01
 
 ### Added

--- a/android/src/main/java/com/theoplayer/cache/CacheModule.kt
+++ b/android/src/main/java/com/theoplayer/cache/CacheModule.kt
@@ -52,34 +52,36 @@ class CacheModule(private val context: ReactApplicationContext) :
 
   init {
     // Add cache event listeners
-    cache?.apply {
-      // Listen for cache state changes
-      addEventListener(CacheEventTypes.CACHE_STATE_CHANGE) { event ->
-        emit("onCacheStatusChange", Arguments.createMap().apply {
-          putString(PROP_STATUS, CacheAdapter.fromCacheStatus(event.status))
-        })
-      }
-      // Listen for add task events
-      tasks.addEventListener(CachingTaskListEventTypes.ADD_TASK) { event ->
-        event.task?.let { task ->
-          // Notify AddCachingTaskEvent event
-          emit("onAddCachingTaskEvent", Arguments.createMap().apply {
-            putMap(PROP_TASK, CacheAdapter.fromCachingTask(task))
+    handler.post {
+      cache?.apply {
+        // Listen for cache state changes
+        addEventListener(CacheEventTypes.CACHE_STATE_CHANGE) { event ->
+          emit("onCacheStatusChange", Arguments.createMap().apply {
+            putString(PROP_STATUS, CacheAdapter.fromCacheStatus(event.status))
           })
-          // Add CachingTask listeners
-          addCachingTaskListeners(task)
+       }
+        // Listen for add task events
+        tasks.addEventListener(CachingTaskListEventTypes.ADD_TASK) { event ->
+          event.task?.let { task ->
+            // Notify AddCachingTaskEvent event
+            emit("onAddCachingTaskEvent", Arguments.createMap().apply {
+              putMap(PROP_TASK, CacheAdapter.fromCachingTask(task))
+            })
+            // Add CachingTask listeners
+            addCachingTaskListeners(task)
+          }
         }
-      }
 
-      // Listen for task removal
-      tasks.addEventListener(CachingTaskListEventTypes.REMOVE_TASK) { event ->
-        event.task?.let { task ->
-          // Notify RemoveCachingTaskEvent event
-          emit("onRemoveCachingTaskEvent", Arguments.createMap().apply {
-            putMap(PROP_TASK, CacheAdapter.fromCachingTask(event.task))
-          })
-          // Remove CachingTask listeners
-          removeCachingTaskListeners(task)
+        // Listen for task removal
+        tasks.addEventListener(CachingTaskListEventTypes.REMOVE_TASK) { event ->
+          event.task?.let { task ->
+            // Notify RemoveCachingTaskEvent event
+            emit("onRemoveCachingTaskEvent", Arguments.createMap().apply {
+              putMap(PROP_TASK, CacheAdapter.fromCachingTask(event.task))
+            })
+            // Remove CachingTask listeners
+            removeCachingTaskListeners(task)
+          }
         }
       }
     }

--- a/example/ios/ReactNativeTHEOplayer/PrivacyInfo.xcprivacy
+++ b/example/ios/ReactNativeTHEOplayer/PrivacyInfo.xcprivacy
@@ -6,10 +6,10 @@
 	<array>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>C617.1</string>
+				<string>35F9.1</string>
 			</array>
 		</dict>
 		<dict>
@@ -22,10 +22,18 @@
 		</dict>
 		<dict>
 			<key>NSPrivacyAccessedAPIType</key>
-			<string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+			<string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>35F9.1</string>
+				<string>C617.1</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>85F4.1</string>
 			</array>
 		</dict>
 	</array>

--- a/ios/THEOplayerRCTBridge.m
+++ b/ios/THEOplayerRCTBridge.m
@@ -228,7 +228,9 @@ RCT_EXTERN_METHOD(getInitialState:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(createTask:(NSDictionary)src
-                  params:(NSDictionary)params)
+                  params:(NSDictionary)params
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 
 RCT_EXTERN_METHOD(startCachingTask:(nonnull NSString *)id)
 

--- a/ios/THEOplayerRCTMainEventHandler.swift
+++ b/ios/THEOplayerRCTMainEventHandler.swift
@@ -317,8 +317,8 @@ public class THEOplayerRCTMainEventHandler {
                let forwardedResizeEvent = self?.onNativeResize {
                 forwardedResizeEvent(
                     [
-                        "width": wplayer.videoWidth,
-                        "height": wplayer.videoHeight,
+                        "width": wplayer.frame.width,
+                        "height": wplayer.frame.height,
                     ]
                 )
             }

--- a/ios/THEOplayerRCTMediaTrackEventHandler.swift
+++ b/ios/THEOplayerRCTMediaTrackEventHandler.swift
@@ -20,8 +20,8 @@ class THEOplayerRCTMediaTrackEventHandler {
     private var videoChangeTrackListener: EventListener?
     
     // MARK: mediaTrack listeners (attached dynamically to new mediatracks)
-    private var audioChangeTrackListeners: [Int:EventListener] = [:]
-    private var videoChangeTrackListeners: [Int:EventListener] = [:]
+    private var videoQualityChangeListeners: [Int:EventListener] = [:]
+    private var audioQualityChangeListeners: [Int:EventListener] = [:]
     
     
     // MARK: - destruction
@@ -56,6 +56,10 @@ class THEOplayerRCTMediaTrackEventHandler {
                     "type" : TrackListEventType.ADD_TRACK.rawValue,
                     "trackType": MediaTrackType.AUDIO.rawValue
                 ])
+                
+                // start listening for qualityChange events on this track
+                welf.audioQualityChangeListeners[audioTrack.uid] = audioTrack.addEventListener(type: MediaTrackEventTypes.ACTIVE_QUALITY_CHANGED, listener: welf.addAudioQualityChangeListener(_:))
+                if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] QualityChange listener attached to THEOplayer audioTrack with uid \(audioTrack.uid)") }
             }
         }
         if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] AddTrack listener attached to THEOplayer audioTrack list") }
@@ -72,6 +76,12 @@ class THEOplayerRCTMediaTrackEventHandler {
                     "type" : TrackListEventType.REMOVE_TRACK.rawValue,
                     "trackType": MediaTrackType.AUDIO.rawValue
                 ])
+                
+                // stop listening for qualityChange events on this track
+                if let audioQualityChangeListener = welf.audioQualityChangeListeners.removeValue(forKey: audioTrack.uid) {
+                    audioTrack.removeEventListener(type: MediaTrackEventTypes.ACTIVE_QUALITY_CHANGED, listener: audioQualityChangeListener)
+                    if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] ActiveQuality listener removed from THEOplayer audioTrack with uid \(audioTrack.uid)") }
+                }
             }
         }
         if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] RemoveTrack listener attached to THEOplayer audioTrack list") }
@@ -104,6 +114,10 @@ class THEOplayerRCTMediaTrackEventHandler {
                     "type" : TrackListEventType.ADD_TRACK.rawValue,
                     "trackType": MediaTrackType.VIDEO.rawValue
                 ])
+                
+                // start listening for qualityChange events on this track
+                welf.videoQualityChangeListeners[videoTrack.uid] = videoTrack.addEventListener(type: MediaTrackEventTypes.ACTIVE_QUALITY_CHANGED, listener: welf.addVideoQualityChangeListener(_:))
+                if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] QualityChange listener attached to THEOplayer videoTrack with uid \(videoTrack.uid)") }
             }
         }
         if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] AddTrack listener attached to THEOplayer videoTrack list") }
@@ -120,6 +134,12 @@ class THEOplayerRCTMediaTrackEventHandler {
                     "type" : TrackListEventType.REMOVE_TRACK.rawValue,
                     "trackType": MediaTrackType.VIDEO.rawValue
                 ])
+                
+                // stop listening for qualityChange events on this track
+                if let videoQualityChangeListener = welf.videoQualityChangeListeners.removeValue(forKey: videoTrack.uid) {
+                    videoTrack.removeEventListener(type: MediaTrackEventTypes.ACTIVE_QUALITY_CHANGED, listener: videoQualityChangeListener)
+                    if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] ActiveQuality listener removed from THEOplayer videoTrack with uid \(videoTrack.uid)") }
+                }
             }
         }
         if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] RemoveTrack listener attached to THEOplayer videoTrack list") }
@@ -180,6 +200,113 @@ class THEOplayerRCTMediaTrackEventHandler {
         if let videoChangeTrackListener = self.videoChangeTrackListener {
             player.videoTracks.removeEventListener(type: VideoTrackListEventTypes.CHANGE, listener: videoChangeTrackListener)
             if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] ChangeTrack listener dettached from THEOplayer videoTrack list") }
+        }
+        
+        // QUALITY CHANGE - AUDIO
+        let audioTrackCount = player.audioTracks.count
+        if audioTrackCount > 0 {
+            for i in 0..<audioTrackCount {
+                let audioTrack = player.audioTracks[i]
+                // stop listening for quality change events on this track
+                if let audioQualityChangeListener = self.audioQualityChangeListeners.removeValue(forKey: audioTrack.uid) {
+                    audioTrack.removeEventListener(type: MediaTrackEventTypes.ACTIVE_QUALITY_CHANGED, listener: audioQualityChangeListener)
+                    if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] ActiveQuality listener removed from THEOplayer audioTrack with uid \(audioTrack.uid)") }
+                }
+            }
+        }
+        
+        // QUALITY CHANGE - VIDEO
+        let videoTrackCount = player.videoTracks.count
+        if videoTrackCount > 0 {
+            for i in 0..<videoTrackCount {
+                let videoTrack = player.videoTracks[i]
+                // stop listening for quality change events on this track
+                if let videoQualityChangeListener = self.videoQualityChangeListeners.removeValue(forKey: videoTrack.uid) {
+                    videoTrack.removeEventListener(type: MediaTrackEventTypes.ACTIVE_QUALITY_CHANGED, listener: videoQualityChangeListener)
+                    if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] ActiveQuality listener removed from THEOplayer videoTrack with uid \(videoTrack.uid)") }
+                }
+            }
+        }
+    }
+    
+    // MARK: - dynamic mediaTrack Listeners
+    private func addVideoQualityChangeListener(_ event: ActiveQualityChangedEvent) {
+        if let forwardedMediaTrackEvent = self.onNativeMediaTrackEvent,
+           let player = self.player,
+           let track = self.activeTrack(tracks: player.videoTracks) {
+            if DEBUG_THEOPLAYER_EVENTS { PrintUtils.printLog(logText: "[NATIVE] Received ACTIVE_QUALITY_CHANGED event for videoTrack") }
+            let identifier = String(track.activeQualityBandwidth)
+            let label = self.labelFromBandWidth(track.activeQualityBandwidth)
+            forwardedMediaTrackEvent([
+                "trackUid" : track.uid,
+                "type" : MediaTrackEventType.ACTIVE_QUALITY_CHANGED.rawValue,
+                "trackType": MediaTrackType.VIDEO.rawValue,
+                "qualities": [
+                    "bandwidth": track.activeQualityBandwidth,
+                    "codecs": "",
+                    "id": identifier,
+                    "uid": identifier,
+                    "name": label,
+                    "label": label,
+                    "available": true,
+                    "width": player.videoWidth,
+                    "height": player.videoHeight,
+                    //"frameRate": 0, // not available on iOS SDK
+                    //"firstFrame": 0 // not available on iOS SDK
+                        
+                ]
+            ])
+        }
+    }
+    
+    private func addAudioQualityChangeListener(_ event: ActiveQualityChangedEvent) {
+        if let forwardedMediaTrackEvent = self.onNativeMediaTrackEvent,
+           let player = self.player,
+           let track = self.activeTrack(tracks: player.audioTracks) {
+            if DEBUG_THEOPLAYER_EVENTS { PrintUtils.printLog(logText: "[NATIVE] Received ACTIVE_QUALITY_CHANGED event for audioTrack") }
+            let identifier = String(track.activeQualityBandwidth)
+            let label = self.labelFromBandWidth(track.activeQualityBandwidth)
+            
+            forwardedMediaTrackEvent([
+                "trackUid" : track.uid,
+                "type" : MediaTrackEventType.ACTIVE_QUALITY_CHANGED.rawValue,
+                "trackType": MediaTrackType.AUDIO.rawValue,
+                "qualities": [
+                    "bandwidth": track.activeQualityBandwidth,
+                    "codecs": "",
+                    "id": identifier,
+                    "uid": identifier,
+                    "name": label,
+                    "label": label,
+                    "available": true,
+                    //"audioSamplingRate": 0 // not available on iOS SDK
+                ]
+            ])
+        }
+    }
+
+    // MARK: - Helpers
+    private func activeTrack(tracks: THEOplayerSDK.MediaTrackList) -> MediaTrack? {
+        guard tracks.count > 0 else {
+            return nil;
+        }
+        var track: MediaTrack?
+        for i in 0...tracks.count-1 {
+           track = tracks.get(i)
+            if (track != nil && track!.enabled) {
+                return track
+            }
+        }
+        return nil;
+    }
+    
+    private func labelFromBandWidth(_ bandWidth: Int) -> String {
+        if bandWidth > 1000000 {
+            return "\(Double(bandWidth / 1000) / 1000) Mbps"
+        } else if bandWidth > 1000 {
+            return "\(bandWidth / 1000) kbps"
+        } else {
+            return "No Label"
         }
     }
 }

--- a/ios/THEOplayerRCTSourceDescriptionAggregator.swift
+++ b/ios/THEOplayerRCTSourceDescriptionAggregator.swift
@@ -6,12 +6,14 @@ import UIKit
 
 #if os(iOS)
 class THEOplayerRCTSourceDescriptionAggregator {
-    class func aggregateCacheTaskSourceDescription(sourceDescription: SourceDescription) -> [String:Any]? {
+    class func aggregateCacheTaskSourceDescription(sourceDescription: SourceDescription, cachingTaskId: String) -> [String:Any]? {
         do {
             let jsonEncoder = JSONEncoder()
             let data = try jsonEncoder.encode(sourceDescription)
             if let result = try? JSONSerialization.jsonObject(with: data, options: []) as? [String:Any] {
-                return THEOplayerRCTSourceDescriptionAggregator.sanitiseSourceDescriptionMetadata(input: result)
+                let srcDescription = THEOplayerRCTSourceDescriptionAggregator.sanitiseSourceDescriptionMetadata(input: result)
+                let extendedSrcDescription = THEOplayerRCTSourceDescriptionAggregator.addCachingTaskIdToMetadata(input: srcDescription, cachingTaskId: cachingTaskId)
+                return extendedSrcDescription
             }
         } catch {
             if DEBUG { PrintUtils.printLog(logText: "[NATIVE] Could not aggregate sourceDescription for caching task: \(error.localizedDescription)")}
@@ -36,6 +38,17 @@ class THEOplayerRCTSourceDescriptionAggregator {
                 newMetadata[key] = value
             }
             output[SD_PROP_METADATA] = newMetadata
+        }
+        return output
+    }
+    
+    private class func addCachingTaskIdToMetadata(input: [String:Any], cachingTaskId: String) -> [String:Any] {
+        var output: [String:Any] = input
+        if var metadata = output[SD_PROP_METADATA] as? [String:Any] {
+            metadata[SD_PROP_METADATA_CACHINGTASK_ID] = cachingTaskId
+            output[SD_PROP_METADATA] = metadata
+        } else {
+            output[SD_PROP_METADATA] = [SD_PROP_METADATA_CACHINGTASK_ID: cachingTaskId]
         }
         return output
     }

--- a/ios/THEOplayerRCTSourceDescriptionBuilder.swift
+++ b/ios/THEOplayerRCTSourceDescriptionBuilder.swift
@@ -12,6 +12,7 @@ let SD_PROP_SOURCES: String = "sources"
 let SD_PROP_POSTER: String = "poster"
 let SD_PROP_TEXTTRACKS: String = "textTracks"
 let SD_PROP_METADATA: String = "metadata"
+let SD_PROP_METADATA_CACHINGTASK_ID: String = "cachingTaskId"
 let SD_PROP_METADATAKEYS: String = "metadataKeys"
 let SD_PROP_SRC: String = "src"
 let SD_PROP_TYPE: String = "type"
@@ -72,6 +73,17 @@ class THEOplayerRCTSourceDescriptionBuilder {
         // 1. Extract "sources"
         guard let sourcesData = sourceData[SD_PROP_SOURCES] else {
             return (nil, nil)
+        }
+        
+        if let metadataData = sourceData[SD_PROP_METADATA] as? [String:Any],
+           let cachingTaskId = metadataData[SD_PROP_METADATA_CACHINGTASK_ID] as? String {
+            // this is a MediaCache src, so fetch the original SourceDescription from the MediaCache
+            let cachingTaskWithId = THEOplayer.cache.tasks.first { cachingTask in
+                cachingTask.id == cachingTaskId
+            }
+            if let foundTask = cachingTaskWithId {
+                return (foundTask.source, nil)
+            }
         }
 
         var typedSources: [TypedSource] = []

--- a/ios/THEOplayerRCTTrackEventTypes.swift
+++ b/ios/THEOplayerRCTTrackEventTypes.swift
@@ -17,3 +17,7 @@ enum TrackCueEventType: Int {
     case ENTER_CUE = 2
     case EXIT_CUE = 3
 }
+
+enum MediaTrackEventType: Int {
+    case ACTIVE_QUALITY_CHANGED = 0
+}

--- a/ios/ads/THEOplayerRCTAdsNative.swift
+++ b/ios/ads/THEOplayerRCTAdsNative.swift
@@ -22,8 +22,14 @@ class NativeAd: THEOplayerSDK.Ad {
     var height: Int? = nil
     /** The kind of the ad integration.*/
     var integration: THEOplayerSDK.AdIntegrationKind = THEOplayerSDK.AdIntegrationKind.defaultKind
+    /** The duration of the LinearAd, as provided by the VAST file, in seconds.*/
+    var duration: Int? = 0
+    /** The url that redirects to the website of the advertiser.*/
+    var clickThrough: String? = nil
+    /**The type of custom ad integration.*/
+    var customIntegration: String? = nil
     
-    init(adBreak: AdBreak? = nil, companions: [THEOplayerSDK.CompanionAd?], type: String, id: String? = nil, skipOffset: Int? = nil, resourceURI: String? = nil, width: Int? = nil, height: Int? = nil, integration: THEOplayerSDK.AdIntegrationKind) {
+    init(adBreak: AdBreak? = nil, companions: [THEOplayerSDK.CompanionAd?], type: String, id: String? = nil, skipOffset: Int? = nil, resourceURI: String? = nil, width: Int? = nil, height: Int? = nil, integration: THEOplayerSDK.AdIntegrationKind, duration: Int? = 0, clickThrough: String?, customIntegration: String?) {
         self.adBreak = adBreak
         self.companions = companions
         self.type = type
@@ -33,18 +39,18 @@ class NativeAd: THEOplayerSDK.Ad {
         self.width = width
         self.height = height
         self.integration = integration
+        self.duration = duration
+        self.clickThrough = clickThrough
+        self.customIntegration = customIntegration
     }
 }
 
 class NativeLinearAd: NativeAd, THEOplayerSDK.LinearAd {
-    /** The duration of the LinearAd, as provided by the VAST file, in seconds.*/
-    var duration: Int? = 0
     /** An array of mediafiles, which provides some meta data retrieved from the VAST file.*/
     var mediaFiles: [THEOplayerSDK.MediaFile] = []
     
-    init(adBreak: AdBreak? = nil, companions: [THEOplayerSDK.CompanionAd?], type: String, id: String? = nil, skipOffset: Int? = nil, resourceURI: String? = nil, width: Int? = nil, height: Int? = nil, integration: THEOplayerSDK.AdIntegrationKind, duration: Int? = 0, mediaFiles: [THEOplayerSDK.MediaFile] = []) {
+    init(adBreak: AdBreak? = nil, companions: [THEOplayerSDK.CompanionAd?], type: String, id: String? = nil, skipOffset: Int? = nil, resourceURI: String? = nil, width: Int? = nil, height: Int? = nil, integration: THEOplayerSDK.AdIntegrationKind, duration: Int? = 0, clickThrough: String? = nil, customIntegration: String? = nil, mediaFiles: [THEOplayerSDK.MediaFile] = []) {
         
-        self.duration = duration
         self.mediaFiles = mediaFiles
         
         super.init(adBreak:adBreak,
@@ -55,7 +61,10 @@ class NativeLinearAd: NativeAd, THEOplayerSDK.LinearAd {
                    resourceURI: resourceURI,
                    width: width,
                    height: height,
-                   integration: integration)
+                   integration: integration,
+                   duration: duration,
+                   clickThrough: clickThrough,
+                   customIntegration: customIntegration)
     }
 }
 
@@ -77,7 +86,7 @@ class NativeLinearGoogleImaAd: NativeLinearAd, THEOplayerSDK.GoogleImaAd {
     /** The String representing custom trafficking parameters from the VAST response.*/
     var traffickingParameters: String = ""
     
-    init(adBreak: AdBreak? = nil, companions: [THEOplayerSDK.CompanionAd?], type: String, id: String? = nil, skipOffset: Int? = nil, resourceURI: String? = nil, width: Int? = nil, height: Int? = nil, integration: THEOplayerSDK.AdIntegrationKind, duration: Int? = 0, mediaFiles: [THEOplayerSDK.MediaFile] = [], adSystem: String? = nil, creativeId: String? = nil, wrapperAdIds: [String], wrapperAdSystems: [String], wrapperCreativeIds: [String], vastMediaBitrate: Int, universalAdIds: [UniversalAdId], traffickingParameters: String) {
+    init(adBreak: AdBreak? = nil, companions: [THEOplayerSDK.CompanionAd?], type: String, id: String? = nil, skipOffset: Int? = nil, resourceURI: String? = nil, width: Int? = nil, height: Int? = nil, integration: THEOplayerSDK.AdIntegrationKind, duration: Int? = 0, clickThrough: String? = nil, customIntegration: String? = nil, mediaFiles: [THEOplayerSDK.MediaFile] = [], adSystem: String? = nil, creativeId: String? = nil, wrapperAdIds: [String], wrapperAdSystems: [String], wrapperCreativeIds: [String], vastMediaBitrate: Int, universalAdIds: [UniversalAdId], traffickingParameters: String) {
         self.adSystem = adSystem
         self.creativeId = creativeId
         self.wrapperAdIds = wrapperAdIds
@@ -97,6 +106,8 @@ class NativeLinearGoogleImaAd: NativeLinearAd, THEOplayerSDK.GoogleImaAd {
                    height: height,
                    integration:integration,
                    duration: duration,
+                   clickThrough: clickThrough,
+                   customIntegration: customIntegration,
                    mediaFiles: mediaFiles)
     }
 }
@@ -110,12 +121,18 @@ class NativeAdBreak: THEOplayerSDK.AdBreak {
     var maxRemainingDuration: Double = -1
     /** The time offset at which point the content will be paused to play the ad break, in seconds.*/
     var timeOffset: Int = 0
+    /** The kind of the ad integration.*/
+    var integration: THEOplayerSDK.AdIntegrationKind = THEOplayerSDK.AdIntegrationKind.defaultKind
+    /**The type of custom ad integration.*/
+    var customIntegration: String? = nil
     
-    init(ads: [Ad], maxDuration: Int, maxRemainingDuration: Double, timeOffset: Int) {
+    init(ads: [Ad], maxDuration: Int, maxRemainingDuration: Double, timeOffset: Int, integration: THEOplayerSDK.AdIntegrationKind, customIntegration: String? = nil) {
         self.ads = ads
         self.maxDuration = maxDuration
         self.maxRemainingDuration = maxRemainingDuration
         self.timeOffset = timeOffset
+        self.integration = integration
+        self.customIntegration = customIntegration
     }
 }
 

--- a/ios/cache/THEOplayerRCTCacheAggregator.swift
+++ b/ios/cache/THEOplayerRCTCacheAggregator.swift
@@ -41,7 +41,7 @@ class THEOplayerRCTCacheAggregator {
         aggregatedData[CACHETASK_PROP_ID] = task.id
         aggregatedData[CACHETASK_PROP_STATUS] = THEOplayerRCTTypeUtils.cachingTaskStatusToString(task.status)
         aggregatedData[CACHETASK_PROP_PARAMETERS] = THEOplayerRCTCacheAggregator.aggregateCacheTaskParameters(params: task.parameters)
-        aggregatedData[CACHETASK_PROP_SOURCE] = THEOplayerRCTSourceDescriptionAggregator.aggregateCacheTaskSourceDescription(sourceDescription: task.source)
+        aggregatedData[CACHETASK_PROP_SOURCE] = THEOplayerRCTSourceDescriptionAggregator.aggregateCacheTaskSourceDescription(sourceDescription: task.source, cachingTaskId: task.id)
         for (key, value) in THEOplayerRCTCacheAggregator.aggregateCacheTaskProgress(task: task) {
             aggregatedData[key] = value
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-theoplayer",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-theoplayer",
-      "version": "7.6.0",
+      "version": "7.7.0",
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
       "dependencies": {
         "buffer": "^6.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-theoplayer",
-  "version": "7.6.0",
+  "version": "7.7.0",
   "description": "A THEOplayer video component for react-native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/react-native-theoplayer.podspec
+++ b/react-native-theoplayer.podspec
@@ -32,23 +32,23 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   
   # THEOplayer core Dependency
-  s.dependency "THEOplayerSDK-core", "~> 7.7"
+  s.dependency "THEOplayerSDK-core", "~> 7.8"
   
   if theofeatures.include?("GOOGLE_IMA") 
 	puts "Adding THEOplayer-Integration-GoogleIMA"
-    s.dependency "THEOplayer-Integration-GoogleIMA/Base", "~> 7.7"
-	s.dependency "THEOplayer-Integration-GoogleIMA/Dependencies", "~> 7.7"
+    s.dependency "THEOplayer-Integration-GoogleIMA/Base", "~> 7.8"
+	s.dependency "THEOplayer-Integration-GoogleIMA/Dependencies", "~> 7.8"
   end
   
   if theofeatures.include?("CHROMECAST")
 	puts "Adding THEOplayer-Integration-GoogleCast"
-    s.ios.dependency "THEOplayer-Integration-GoogleCast/Base", "~> 7.7"
+    s.ios.dependency "THEOplayer-Integration-GoogleCast/Base", "~> 7.8"
 	s.ios.dependency "google-cast-sdk-dynamic-xcframework", "~> 4.8"
   end
   
   if theofeatures.include?("SIDELOADED_TEXTTRACKS") 
 	puts "Adding THEOplayer-Connector-SideloadedSubtitle"
-    s.dependency "THEOplayer-Connector-SideloadedSubtitle", "~> 7.4"
+    s.dependency "THEOplayer-Connector-SideloadedSubtitle", "~> 7.8"
   end
   
 end

--- a/react-native-theoplayer.podspec
+++ b/react-native-theoplayer.podspec
@@ -32,17 +32,17 @@ Pod::Spec.new do |s|
   s.dependency "React-Core"
   
   # THEOplayer core Dependency
-  s.dependency "THEOplayerSDK-core", "~> 7.4"
+  s.dependency "THEOplayerSDK-core", "~> 7.7"
   
   if theofeatures.include?("GOOGLE_IMA") 
 	puts "Adding THEOplayer-Integration-GoogleIMA"
-    s.dependency "THEOplayer-Integration-GoogleIMA/Base", "~> 7.4"
-	s.dependency "THEOplayer-Integration-GoogleIMA/Dependencies", "~> 7.4"
+    s.dependency "THEOplayer-Integration-GoogleIMA/Base", "~> 7.7"
+	s.dependency "THEOplayer-Integration-GoogleIMA/Dependencies", "~> 7.7"
   end
   
   if theofeatures.include?("CHROMECAST")
 	puts "Adding THEOplayer-Integration-GoogleCast"
-    s.ios.dependency "THEOplayer-Integration-GoogleCast/Base", "~> 7.4"
+    s.ios.dependency "THEOplayer-Integration-GoogleCast/Base", "~> 7.7"
 	s.ios.dependency "google-cast-sdk-dynamic-xcframework", "~> 4.8"
   end
   


### PR DESCRIPTION
## [7.7.0] - 24-07-25

### Added

- Added ActiveQualityChanged event support for iOS.

### Fixed

- Fixed an issue where on iOS a cached asset would not play when setting the tasks's source on the player.
- Fixed an issue where on iOS the createTask method (CacheAPI) was not returning the created task.
- Fixed an issue where on iOS the Ad and AdBreak protocols where extended in the underlying native SDK and required some modifications.
- Fixed an issue where on Android the native module preparation would fail due to a change in the Android SDK 7.8.0 on eventDispatching.
