### PR TITLE
Feature/add missing skip buttons to android notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Added
+
+- Added the fast-forward & rewind buttons for the Android notification when `mediaControl.mediaSessionEnabled` is set to `true`.
+
 ## [7.7.1] - 24-07-29
 
 ### Fixed

--- a/android/src/main/java/com/theoplayer/media/MediaNotificationBuilder.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaNotificationBuilder.kt
@@ -67,6 +67,22 @@ class MediaNotificationBuilder(
     )
   )
 
+  private val forwardAction = NotificationCompat.Action(
+    R.drawable.ic_fast_forward, context.getString(R.string.ffd_pip),
+    MediaButtonReceiver.buildMediaButtonPendingIntent(
+      context,
+      PlaybackStateCompat.ACTION_FAST_FORWARD
+    )
+  )
+
+  private val rewindAction = NotificationCompat.Action(
+    R.drawable.ic_rewind, context.getString(R.string.rwd_pip),
+    MediaButtonReceiver.buildMediaButtonPendingIntent(
+      context,
+      PlaybackStateCompat.ACTION_REWIND
+    )
+  )
+
   fun build(
     @PlaybackStateCompat.State playbackState: Int,
     largeIcon: Bitmap?,
@@ -130,13 +146,15 @@ class MediaNotificationBuilder(
       // on the eyes and avoid extremely bright or fluorescent colors.
       color = ContextCompat.getColor(context, R.color.app_primary_color)
 
-      // Add a play/pause button
+      // Add play/pause, rewind and fast-forward buttons.
       if (enableMediaControls) {
+        addAction(rewindAction)
         if (playbackState == PlaybackStateCompat.STATE_PAUSED) {
           addAction(playAction)
         } else if (playbackState == PlaybackStateCompat.STATE_PLAYING) {
           addAction(pauseAction)
         }
+        addAction(forwardAction)
       } else {
         // Add empty placeholder action as clearActions() does not work.
         addAction(0, null, null)

--- a/android/src/main/java/com/theoplayer/media/MediaNotificationBuilder.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaNotificationBuilder.kt
@@ -68,7 +68,7 @@ class MediaNotificationBuilder(
   )
 
   private val forwardAction = NotificationCompat.Action(
-    R.drawable.ic_fast_forward, context.getString(R.string.ffd_pip),
+    R.drawable.ic_fast_forward, context.getString(R.string.fast_forward),
     MediaButtonReceiver.buildMediaButtonPendingIntent(
       context,
       PlaybackStateCompat.ACTION_FAST_FORWARD
@@ -76,7 +76,7 @@ class MediaNotificationBuilder(
   )
 
   private val rewindAction = NotificationCompat.Action(
-    R.drawable.ic_rewind, context.getString(R.string.rwd_pip),
+    R.drawable.ic_rewind, context.getString(R.string.rewind),
     MediaButtonReceiver.buildMediaButtonPendingIntent(
       context,
       PlaybackStateCompat.ACTION_REWIND

--- a/android/src/main/java/com/theoplayer/media/MediaNotificationBuilder.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaNotificationBuilder.kt
@@ -168,7 +168,13 @@ class MediaNotificationBuilder(
       style.setMediaSession(mediaSession.sessionToken)
 
       // Add up to 3 actions to be shown in the notification's standard-sized contentView.
-      style.setShowActionsInCompactView(0)
+      if (enableMediaControls) {
+        // The Rewind, Play/Pause and FastForward actions.
+        style.setShowActionsInCompactView(0,1,2)
+      } else {
+        // The placeholder action, which was added above.
+        style.setShowActionsInCompactView(0)
+      }
 
       if (enableCancelButton) {
         // In Android 5.0 (API level 21) and later you can swipe away a notification to

--- a/android/src/main/java/com/theoplayer/presentation/PipUtils.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PipUtils.kt
@@ -130,8 +130,8 @@ class PipUtils(
           buildRemoteAction(
             ACTION_RWD,
             R.drawable.ic_rewind,
-            R.string.rwd_pip,
-            R.string.rwd_desc_pip
+            R.string.rewind,
+            R.string.rewind_description
           )
         )
       }
@@ -144,16 +144,16 @@ class PipUtils(
           buildRemoteAction(
             ACTION_PLAY,
             R.drawable.ic_play,
-            R.string.play_pip,
-            R.string.play_desc_pip,
+            R.string.play,
+            R.string.play_description,
             enablePlayPause
           )
         } else {
           buildRemoteAction(
             ACTION_PAUSE,
             R.drawable.ic_pause,
-            R.string.pause_pip,
-            R.string.pause_desc_pip,
+            R.string.play,
+            R.string.pause_description,
             enablePlayPause
           )
         }
@@ -165,8 +165,8 @@ class PipUtils(
           buildRemoteAction(
             ACTION_FFD,
             R.drawable.ic_fast_forward,
-            R.string.ffd_pip,
-            R.string.ffd_desc_pip
+            R.string.fast_forward,
+            R.string.fast_forward_description
           )
         )
       }

--- a/android/src/main/res/values/strings.xml
+++ b/android/src/main/res/values/strings.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-  <string name="pause">Pause</string>
   <string name="play">Play</string>
-  <string name="pause_pip">Pause</string>
-  <string name="pause_desc_pip">Pause video</string>
-  <string name="play_pip">Play</string>
-  <string name="play_desc_pip">Play video</string>
-  <string name="ffd_pip">Fast Forward</string>
-  <string name="ffd_desc_pip">Fast Forward video</string>
-  <string name="rwd_pip">Rewind</string>
-  <string name="rwd_desc_pip">Rewind video</string>
+  <string name="play_description">Play video</string>
+  <string name="pause">Pause</string>
+  <string name="pause_description">Pause video</string>
+  <string name="fast_forward">Fast Forward</string>
+  <string name="fast_forward_description">Fast Forward video</string>
+  <string name="rewind">Rewind</string>
+  <string name="rewind_description">Rewind video</string>
 
   <string name="background_playback_service_description">THEOplayer service providing background playback.</string>
   <string name="notification_channel_id">theoplayer_default_channel</string>


### PR DESCRIPTION
This PR adds a fast-forward & rewind button the the notification on Android for controlling the player during background playback.

The durations are able to be customized using the `PlayerConfiguration.mediaControl` API ([see documentation here](https://theoplayer.github.io/react-native-theoplayer/api/interfaces/MediaControlConfiguration.html))

Example screenshot:

![Screenshot_2024-07-31-14-10-20-20_34eeb7b37d03542cde456cc7275b399a](https://github.com/user-attachments/assets/97541db0-b769-4971-a04b-7651ad3e72f5)
