### PR TITLE
Feature/mediaservice improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added the fast-forward & rewind buttons for the Android notification when `mediaControl.mediaSessionEnabled` is set to `true`.
 
+### Fixed
+
+- Fixed an issue on Android where the notification would not disappear when setting an undefined source.
+
+### Changed
+
+- Replaced the `MediaBrowserService` with a regular `Service` to facilitate background playback on Android.
+
 ## [7.7.1] - 24-07-29
 
 ### Fixed

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -38,7 +38,6 @@
       android:enabled="true"
       android:foregroundServiceType="mediaPlayback">
       <intent-filter>
-        <action android:name="android.media.browse.MediaBrowserService" />
         <action android:name="android.intent.action.MEDIA_BUTTON" />
       </intent-filter>
     </service>

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -37,17 +37,7 @@
       android:exported="false"
       android:enabled="true"
       android:foregroundServiceType="mediaPlayback">
-      <intent-filter>
-        <action android:name="android.intent.action.MEDIA_BUTTON" />
-      </intent-filter>
     </service>
-
-    <receiver android:name="androidx.media.session.MediaButtonReceiver"
-      android:exported="false">
-      <intent-filter>
-        <action android:name="android.intent.action.MEDIA_BUTTON" />
-      </intent-filter>
-    </receiver>
 
   </application>
 

--- a/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
@@ -200,12 +200,11 @@ class MediaPlaybackService : Service() {
   }
 
   private fun updateNotification() {
-    player?.let {
-      if (it.isPaused) {
-        updateNotification(PlaybackStateCompat.STATE_PAUSED)
-      } else {
-        updateNotification(PlaybackStateCompat.STATE_PLAYING)
-      }
+    val player = player
+    when {
+      player?.source == null -> updateNotification(PlaybackStateCompat.STATE_STOPPED)
+      !player.isPaused -> updateNotification(PlaybackStateCompat.STATE_PLAYING)
+      else -> updateNotification(PlaybackStateCompat.STATE_PAUSED)
     }
   }
 

--- a/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
@@ -6,16 +6,12 @@ import android.content.pm.ServiceInfo
 import android.graphics.Bitmap
 import android.os.Binder
 import android.os.Build
-import android.os.Bundle
 import android.os.IBinder
-import android.support.v4.media.MediaBrowserCompat
 import android.support.v4.media.session.MediaSessionCompat
 import android.support.v4.media.session.PlaybackStateCompat
-import android.text.TextUtils
 import android.util.Log
 import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
-import androidx.media.MediaBrowserServiceCompat
 import androidx.media.session.MediaButtonReceiver
 import com.theoplayer.BuildConfig
 import com.theoplayer.ReactTHEOplayerContext
@@ -23,15 +19,13 @@ import com.theoplayer.android.api.player.Player
 import com.theoplayer.android.connector.mediasession.MediaSessionConnector
 import com.theoplayer.android.connector.mediasession.MediaSessionListener
 
-private const val BROWSABLE_ROOT = "/"
-private const val EMPTY_ROOT = "@empty@"
 private const val STOP_SERVICE_IF_APP_REMOVED = true
 
 private const val NOTIFICATION_ID = 1
 
 private const val TAG = "MediaPlaybackService"
 
-class MediaPlaybackService : MediaBrowserServiceCompat() {
+class MediaPlaybackService : Service() {
 
   private lateinit var notificationManager: NotificationManager
   private lateinit var notificationBuilder: MediaNotificationBuilder
@@ -175,9 +169,6 @@ class MediaPlaybackService : MediaBrowserServiceCompat() {
       // Set mediaSession active
       setActive(BuildConfig.EXTENSION_MEDIASESSION)
     }
-
-    // Set the MediaBrowserServiceCompat's media session.
-    sessionToken = mediaSession.sessionToken
   }
 
   private fun stopForegroundService() {
@@ -208,41 +199,6 @@ class MediaPlaybackService : MediaBrowserServiceCompat() {
     mediaSessionConnector.removeListener(mediaSessionListener)
   }
 
-  override fun onGetRoot(
-    clientPackageName: String,
-    clientUid: Int,
-    rootHints: Bundle?
-  ): BrowserRoot {
-    // (Optional) Control the level of access for the specified package name.
-    // You'll need to write your own logic to do this.
-    return if (allowBrowsing(clientPackageName, clientUid)) {
-      // Returns a root ID that clients can use with onLoadChildren() to retrieve
-      // the content hierarchy.
-      BrowserRoot(BROWSABLE_ROOT, null)
-    } else {
-      // Clients can connect, but this BrowserRoot is an empty hierachy
-      // so onLoadChildren returns nothing. This disables the ability to browse for content.
-      BrowserRoot(EMPTY_ROOT, null)
-    }
-  }
-
-  @Suppress("UNUSED_PARAMETER")
-  private fun allowBrowsing(clientPackageName: String, clientUid: Int): Boolean {
-    // Only allow browsing from the same package
-    return TextUtils.equals(clientPackageName, packageName)
-  }
-
-  override fun onLoadChildren(
-    parentId: String,
-    result: Result<List<MediaBrowserCompat.MediaItem>>
-  ) {
-    if (parentId == EMPTY_ROOT) {
-      result.sendResult(null)
-      return
-    }
-    result.sendResult(emptyList())
-  }
-
   private fun updateNotification() {
     player?.let {
       if (it.isPaused) {
@@ -254,7 +210,6 @@ class MediaPlaybackService : MediaBrowserServiceCompat() {
   }
 
   private fun updateNotification(@PlaybackStateCompat.State playbackState: Int) {
-
     // When a service is playing, it should be running in the foreground.
     // This lets the system know that the service is performing a useful function and should
     // not be killed if the system is low on memory.


### PR DESCRIPTION
Some simplifications/improvements to the mediaService facilitating background playback on Android:

- Use a regular `Service` instead of a `MediaBrowserService`. The browser service was private anyway, so no external apps could connect to it. It also prohibits any other browser service to be implemented by the hosting app, as there can be only one registered MediaBrowserService.
- Remove the notification when the player's source is unset (undefined).
- Remove the need for `MediaButtonReceiver` broadcast receiver and intent listener: as of API 21+, all media buttons are [routed to the active media session](https://developer.android.com/media/legacy/media-buttons#mediabuttons-and-active-mediasessions). And we do not want the background service to be (re)started if the app was closed, so there is no need for the`MediaButtonReceiver` helper.