### PR TITLE
Bugfix/android notification posterres

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue on Android where the notification background would be displayed in low resolution on recent Android versions.
+
 ## [7.8.0] - 24-08-09
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -113,8 +113,8 @@ dependencies {
   implementation "androidx.core:core-ktx:${safeExtGet('corektxVersion', '1.10.1')}"
 
   // The minimum supported THEOplayer version is 7.6.0
-  def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[7.6.0, 8.0.0)')
-  def theoplayer_mediasession_version = safeExtGet('THEOplayer_mediasession', '[7.5.0, 8.0.0)')
+  def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[7.10.0, 8.0.0)')
+  def theoplayer_mediasession_version = safeExtGet('THEOplayer_mediasession', '[7.10.0, 8.0.0)')
 
   println("Using THEOplayer (${versionString(theoplayer_sdk_version)})")
   implementation "com.theoplayer.theoplayer-sdk-android:core:${theoplayer_sdk_version}"

--- a/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
@@ -77,7 +77,7 @@ class MediaPlaybackService : Service() {
     initMediaSession()
 
     notificationManager = (getSystemService(NOTIFICATION_SERVICE) as NotificationManager)
-    notificationBuilder = MediaNotificationBuilder(this, notificationManager, mediaSession)
+    notificationBuilder = MediaNotificationBuilder(this, notificationManager, mediaSessionConnector)
 
     // This ensures that the service starts and continues to run, even when all
     // UI MediaBrowser activities that are bound to it unbind.
@@ -215,7 +215,7 @@ class MediaPlaybackService : Service() {
     when (playbackState) {
       PlaybackStateCompat.STATE_PAUSED -> {
         // Fetch large icon asynchronously
-        fetchImageFromUri(mediaSession.controller.metadata?.description?.iconUri) { largeIcon ->
+        fetchImageFromMetadata(player?.source) { largeIcon ->
           notificationManager.notify(NOTIFICATION_ID, notificationBuilder.build(playbackState, largeIcon, mediaSessionConfig.mediaSessionEnabled))
         }
       }
@@ -228,7 +228,7 @@ class MediaPlaybackService : Service() {
         startForegroundWithPlaybackState(playbackState, loadPlaceHolderIcon(this))
 
         // Fetch the correct large icon asynchronously.
-        fetchImageFromUri(mediaSession.controller.metadata?.description?.iconUri) { largeIcon ->
+        fetchImageFromMetadata(player?.source) { largeIcon ->
           startForegroundWithPlaybackState(playbackState, largeIcon)
         }
       }

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -41,7 +41,7 @@ newArchEnabled=false
 hermesEnabled=true
 
 # Version of the THEOplayer SDK, if not specified, the latest available version within bounds is set.
-#THEOplayer_sdk=[7.6.0, 8.0.0)
+#THEOplayer_sdk=[7.10.0, 8.0.0)
 
 # Override Android sdk versions
 #THEOplayer_compileSdkVersion = 34


### PR DESCRIPTION
Fix for the notification background resolution on Android:

When setting the largeIcon bitmap, a scaled-down version is used for the notification background, resulting in a pixelated background.
As a fix, we also provide the mediaSession's `METADATA_KEY_ART_URI` metadata property with the downloaded bitmap. The `MediaStyle` notification uses these properties, in order, to get a correct background:

MediaMetadata.METADATA_KEY_ALBUM_ART_URI
MediaMetadata.METADATA_KEY_ART_URI
MediaMetadata.METADATA_KEY_DISPLAY_ICON_URI
MediaMetadata.METADATA_KEY_ART
MediaMetadata.METADATA_KEY_ALBUM_ART
Notification largeIcon 

Note that the _URI properties cannot be used; they assume a ContentProvider that downloads the Bitmap.