### PR TITLE
Bugfix/poster onplaying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Modified the poster behavior on iOS and Android to remain visible until the first frame is displayed.
+
 ## [7.8.1] - 24-08-14
 
 ### Fixed

--- a/src/internal/THEOplayerView.tsx
+++ b/src/internal/THEOplayerView.tsx
@@ -229,11 +229,11 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
 
   private _onPlay = () => {
     this._facade.dispatchEvent(new BaseEvent(PlayerEventType.PLAY));
-    this._hidePoster();
   };
 
   private _onPlaying = () => {
     this._facade.dispatchEvent(new BaseEvent(PlayerEventType.PLAYING));
+    this._hidePoster();
   };
 
   private _onPause = () => {


### PR DESCRIPTION
Keep the poster visible until the first frame is displayed, on iOS & Android. This improves user experience while waiting for a stream to start playing.