### PR TITLE
Bugfix/no cast events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added support for `bitrate` config on the GoogleIMAConfiguration, to be passed to the IMA SDK rendering settings.
 - Added support on iOS and Android for `allowedMimeTypes` config on the AdsConfiguration, to be passed to the IMA SDK rendering settings.
 
+### Fixed
+
+- Fixed an issue where cast events were not forwarded from the hative Android SDK.
+
 ## [8.0.3] - 24-09-14
 
 ### Fixed

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerView.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerView.kt
@@ -52,7 +52,8 @@ class ReactTHEOplayerView(private val reactContext: ThemedReactContext) :
     playerContext = ReactTHEOplayerContext.create(
       reactContext,
       PlayerConfigAdapter(configProps)
-    ).apply {
+    )
+    playerContext?.apply {
       adsApi.initialize(player, imaIntegration, daiIntegration)
       val layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
       playerView.layoutParams = layoutParams


### PR DESCRIPTION
This PR fixes an issue where cast related events from the native Android SDK were not being forwarded. This also led to out of sync values for `player.cast.chromecast.state` and `player.cast.chromecast.casting`.