### PR TITLE
Feature/playbacksettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### [Unreleased]
+
+### Added
+
+- Added the `PlaybackSettings` API for Android, allowing control of playback behaviour across all THEOplayer instances.
+
 ## [8.1.0] - 24-09-23
 
 ### Added

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -114,9 +114,9 @@ dependencies {
   implementation "androidx.core:core-ktx:${safeExtGet('corektxVersion', '1.10.1')}"
   implementation "com.google.code.gson:gson:2.11.0"
 
-  // The minimum supported THEOplayer version is 7.12.0
-  def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[7.12.0, 9.0.0)')
-  def theoplayer_mediasession_version = safeExtGet('THEOplayer_mediasession', '[7.12.0, 9.0.0)')
+  // The minimum supported THEOplayer version is 8.1.0
+  def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[8.1.0, 9.0.0)')
+  def theoplayer_mediasession_version = safeExtGet('THEOplayer_mediasession', '[8.1.0, 9.0.0)')
 
   println("Using THEOplayer (${versionString(theoplayer_sdk_version)})")
   implementation "com.theoplayer.theoplayer-sdk-android:core:${theoplayer_sdk_version}"

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerPackage.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerPackage.kt
@@ -9,6 +9,7 @@ import com.theoplayer.cache.CacheModule
 import com.theoplayer.drm.ContentProtectionModule
 import com.theoplayer.cast.CastModule
 import com.theoplayer.broadcast.EventBroadcastModule
+import com.theoplayer.playback.PlaybackSettingsModule
 import com.theoplayer.player.PlayerModule
 
 class ReactTHEOplayerPackage : ReactPackage {
@@ -19,7 +20,8 @@ class ReactTHEOplayerPackage : ReactPackage {
       ContentProtectionModule(reactContext),
       CastModule(reactContext),
       CacheModule(reactContext),
-      EventBroadcastModule(reactContext)
+      EventBroadcastModule(reactContext),
+      PlaybackSettingsModule(reactContext)
     )
   }
 

--- a/android/src/main/java/com/theoplayer/playback/PlaybackSettingsModule.kt
+++ b/android/src/main/java/com/theoplayer/playback/PlaybackSettingsModule.kt
@@ -1,0 +1,28 @@
+package com.theoplayer.playback
+
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+import com.theoplayer.android.api.THEOplayerGlobal
+import com.theoplayer.android.api.settings.PlaybackSettings
+
+class PlaybackSettingsModule(private val context: ReactApplicationContext) :
+  ReactContextBaseJavaModule(context) {
+
+  private val playbackSettings: PlaybackSettings
+    get() = THEOplayerGlobal.getSharedInstance(context.applicationContext).playbackSettings
+
+  override fun getName(): String {
+    return "THEORCTPlaybackSettingsModule"
+  }
+
+  @ReactMethod
+  fun useFastStartup(useFastStartup: Boolean) {
+    playbackSettings.useFastStartup(useFastStartup)
+  }
+
+  @ReactMethod
+  fun setLipSyncCorrection(correctionMs: Double) {
+    playbackSettings.setLipSyncCorrection(correctionMs.toLong())
+  }
+}

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -41,7 +41,7 @@ newArchEnabled=false
 hermesEnabled=true
 
 # Version of the THEOplayer SDK, if not specified, the latest available version within bounds is set.
-#THEOplayer_sdk=[7.12.0, 9.0.0)
+#THEOplayer_sdk=[8.1.0, 9.0.0)
 
 # Override Android sdk versions
 #THEOplayer_compileSdkVersion = 34

--- a/src/api/playback/PlaybackSettingsAPI.ts
+++ b/src/api/playback/PlaybackSettingsAPI.ts
@@ -1,0 +1,39 @@
+/**
+ * The playback settings for all instances of THEOplayer.
+ */
+export interface PlaybackSettingsAPI {
+
+  /**
+   * The player starts the playback as soon as the first video data is available related to the initial playback position.
+   *
+   * <ul>
+   *     <li>Using this feature will sacrifice the accuracy of the initial seek position
+   *     <li>This API is in an experimental stage and may be subject to breaking changes.
+   * </ul>
+   *
+   * @experimental
+   * @param {boolean} useFastStartup Whether fast startup is enabled.
+   *
+   * @remarks
+   * - This API is experimental.
+   * - This property is supported on Android platforms only.
+   */
+  useFastStartup(useFastStartup: boolean): void;
+
+  /**
+   * Sets the lip sync correction delay.
+   *
+   * This method adjusts the synchronization between audio and video playback for all instances of THEOplayer
+   * by applying a specified correction delay.
+   *
+   * @experimental
+   * @since Native THEOplayer SDK v8.1.0.
+   * @param {number} correctionMs The correction delay in milliseconds.
+   *                              Positive values advance the audio, while negative values delay it.
+   *
+   * @remarks
+   * - This API is experimental.
+   * - This property is supported on Android platforms only.
+   */
+  setLipSyncCorrection(correctionMs: number): void;
+}

--- a/src/api/playback/barrel.ts
+++ b/src/api/playback/barrel.ts
@@ -1,0 +1,1 @@
+export * from './PlaybackSettingsAPI';

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,3 +2,4 @@ export * from './api/barrel';
 export { THEOplayerView } from './internal/THEOplayerView';
 export { ContentProtectionRegistry } from './internal/drm/ContentProtectionRegistry';
 export { MediaCache } from './internal/cache/MediaCache';
+export { PlaybackSettings } from './internal/playback/PlaybackSettings';

--- a/src/internal/playback/PlaybackSettings.ts
+++ b/src/internal/playback/PlaybackSettings.ts
@@ -1,0 +1,25 @@
+import { NativeModules, Platform } from 'react-native';
+import { PlaybackSettingsAPI } from '../../api/playback/PlaybackSettingsAPI';
+
+const NativePlaybackSettingsModule = NativeModules.THEORCTPlaybackSettingsModule;
+
+const TAG = 'PlaybackSettings';
+
+export class NativePlaybackSettings implements PlaybackSettingsAPI {
+  useFastStartup(useFastStartup: boolean): void {
+    if (Platform.OS !== 'android') {
+      console.warn(TAG, 'useFastStartup is only available on Android platforms.');
+      return;
+    }
+    NativePlaybackSettingsModule.useFastStartup(useFastStartup);
+  }
+  setLipSyncCorrection(correctionMs: number): void {
+    if (Platform.OS !== 'android') {
+      console.warn(TAG, 'setLipSyncCorrect is only available on Android platforms.');
+      return;
+    }
+    NativePlaybackSettingsModule.setLipSyncCorrection(correctionMs);
+  }
+}
+
+export const PlaybackSettings: PlaybackSettingsAPI = new NativePlaybackSettings();


### PR DESCRIPTION
Added `PlaybackSettings` API, currently for Android only.

Only the experimental `setLipSyncCorrection` and `useFastStartup` methods are added for now. We'll add codec control later on.

This requires **native SDK v8.1.0**, so merge after release.