### PR TITLE
Suggestion / Extend the versions scope for integration-ads and integration-ads-ima

### DIFF
--- a/android/local/com/theoplayer/theoplayer-sdk-android/ads-wrapper/8.0.0/ads-wrapper-8.0.0.pom
+++ b/android/local/com/theoplayer/theoplayer-sdk-android/ads-wrapper/8.0.0/ads-wrapper-8.0.0.pom
@@ -11,13 +11,13 @@
     <dependency>
       <groupId>com.theoplayer.theoplayer-sdk-android</groupId>
       <artifactId>integration-ads</artifactId>
-      <version>8.0.0</version>
+      <version>[8.0.0,)</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>com.theoplayer.theoplayer-sdk-android</groupId>
       <artifactId>integration-ads-ima</artifactId>
-      <version>8.0.0</version>
+      <version>[8.0.0,)</version>
       <scope>runtime</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
**Description:**

_Version used:_ 
in packages.json:
`    "react-native-theoplayer": "8.1.0" (same happens for 8.2.0)`
in gradle.properties:
```
    THEOplayer_extensionGoogleIMA=false
    THEOplayer_sdk=8.1.0
    THEOplayer_mediasession=8.1.0
```

There's an Android build issue occurring given `THEOplayer_extensionGoogleIMA=false` for react-native-theoplayer v8.1.0+:
```
   > Could not resolve com.theoplayer.theoplayer-sdk-android:integration-ads:{strictly 8.0.0}.
     Required by:
         project :react-native-theoplayer
      > Cannot find a version of 'com.theoplayer.theoplayer-sdk-android:integration-ads' that satisfies the version constraints:
           Dependency path 'NFLNetwork:react-native-theoplayer:unspecified' --> 'com.theoplayer.theoplayer-sdk-android:integration-ads:8.1.0'
           Constraint path 'NFLNetwork:react-native-theoplayer:unspecified' --> 'com.theoplayer.theoplayer-sdk-android:integration-ads:{strictly 8.0.0}' because of the following reason: debugRuntimeClasspath uses version 8.0.0
   > Could not resolve com.theoplayer.theoplayer-sdk-android:integration-ads-ima:{strictly 8.0.0}.
     Required by:
         project :react-native-theoplayer
      > Cannot find a version of 'com.theoplayer.theoplayer-sdk-android:integration-ads-ima' that satisfies the version constraints:
           Dependency path 'NFLNetwork:react-native-theoplayer:unspecified' --> 'com.theoplayer.theoplayer-sdk-android:integration-ads-ima:8.1.0'
           Constraint path 'NFLNetwork:react-native-theoplayer:unspecified' --> 'com.theoplayer.theoplayer-sdk-android:integration-ads-ima:{strictly 8.0.0}' because of the following reason: debugRuntimeClasspath uses version 8.0.0
```
compileOnly in build.gradle seems to rely on pom file node_modules/react-native-theoplayer/android/local/com/theoplayer/theoplayer-sdk-android/ads-wrapper/8.0.0/ads-wrapper-8.0.0.pom  which pins strictly to 8.0.0.
[the corresponding change](https://github.com/THEOplayer/react-native-theoplayer/commit/81edeae0e83e8ff15413377819f8f86d0fee5798)
I'm not 100% sure about the desired behavior so I assume that the goal was to make it compile with at least (not lower than) 8.0.0.

**Test-plan:**
- Android build should pass with `THEOplayer_extensionGoogleIMA=false`