### PR TITLE
Bugfix/notification mediabutton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed an issue on Android where on some Android SDK versions controlling playback with the notification buttons would not work.
 - Fixed an issue on Web and Android where a text track with attribute `DEFAULT` was not set as the player's `selectedTextTrack` property.
 
 ## [8.3.0] - 24-09-30

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -37,7 +37,17 @@
       android:exported="false"
       android:enabled="true"
       android:foregroundServiceType="mediaPlayback">
+      <intent-filter>
+        <action android:name="android.intent.action.MEDIA_BUTTON" />
+      </intent-filter>
     </service>
+
+  <receiver android:name="androidx.media.session.MediaButtonReceiver"
+    android:exported="false">
+    <intent-filter>
+      <action android:name="android.intent.action.MEDIA_BUTTON" />
+    </intent-filter>
+  </receiver>
 
   </application>
 

--- a/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
@@ -141,25 +141,9 @@ class MediaPlaybackService : Service() {
         )
       }
 
-    // Sets a pending intent for your media button receiver to allow restarting playback after
-    // the session has been stopped.
-    val mediaButtonPendingIntent = PendingIntent.getBroadcast(
-      this@MediaPlaybackService,
-      0,
-      Intent(
-        Intent.ACTION_MEDIA_BUTTON, null, applicationContext, MediaButtonReceiver::class.java
-      ),
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-        PendingIntent.FLAG_IMMUTABLE
-      } else {
-        PendingIntent.FLAG_ONE_SHOT
-      }
-    )
-
     // Create and initialize the media session
     val mediaSession = MediaSessionCompat(this, TAG).apply {
       setSessionActivity(sessionActivityPendingIntent)
-      setMediaButtonReceiver(mediaButtonPendingIntent)
     }
 
     // Create a MediaSessionConnector.


### PR DESCRIPTION
- Re-introduce the media button receiver for Android versions that do not route the event through the MediaSession (although it should, for versions > API21)
- Remove the ability to restart the service using a media button event.

Tagging @kot331107 , FYI