### PR TITLE
Feature/theoads config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added a `posterStyle` property on `THEOplayerView` to allow overriding the default 16:9 poster style.
+- Added a `theoads` property on `PlayerConfiguration.ads` to allow play-out of THEOads sources on Web platforms.
+- Added a `hlsDateRange` property on `SourceDescription` to enable parsing and exposing date ranges from HLS playlists. This flag was already available on `PlayerConfiguration`, which applies for all HLS sources.
 
 ## [8.3.1] - 24-10-07
 

--- a/src/api/ads/AdsConfiguration.ts
+++ b/src/api/ads/AdsConfiguration.ts
@@ -52,6 +52,20 @@ export interface AdsConfiguration {
    * <br/> - This is only available to define IMA Settings on iOS and/or Android.
    */
   ima?: GoogleImaConfiguration;
+
+  /**
+   * Whether to enable THEOads support.
+   *
+   * @since React Native THEOplayer SDK v8.4.0.
+   * @since Native THEOplayer SDK v8.2.0.
+   *
+   * @remarks
+   * <br/> - This must be set to `true` in order to schedule a {@link TheoAdDescription}.
+   * <br/> - This only applies to Web platforms.
+   *
+   * @defaultValue `false`
+   */
+  theoads?: boolean;
 }
 
 /**

--- a/src/api/source/SourceDescription.ts
+++ b/src/api/source/SourceDescription.ts
@@ -93,6 +93,13 @@ export interface SourceConfiguration {
   timeServer?: string;
 
   /**
+   * Whether the player should parse and expose date ranges from HLS playlists.
+   *
+   * @defaultValue `false`
+   */
+  hlsDateRange?: boolean;
+
+  /**
    * Describes the metadata of a source.
    *
    * @public


### PR DESCRIPTION
Two properties:

- a `theoads` property on `PlayerConfiguration.ads` to allow play-out of THEOads sources on Web platforms.
- a `hlsDateRange` property on `SourceDescription` to enable parsing and exposing date ranges from HLS playlists. This flag was already available on `PlayerConfiguration`, which applies for all HLS sources.
