### PR TITLE
Bugfix/android dont restart service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- The `MediaPlaybackService` on Android is never restarted if a MediaButton event is received after the app was closed.
+
 ## [8.7.0] - 24-11-05
 
 ### Fixed

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -239,7 +239,8 @@ class ReactTHEOplayerContext private constructor(
     // Create and initialize the media session
     val mediaSession = MediaSessionCompat(reactContext, TAG)
 
-    // Do not let MediaButtons restart the player when the app is not visible
+    // Do not let MediaButtons restart the player when media session is not active.
+    // https://developer.android.com/media/legacy/media-buttons#restarting-inactive-mediasessions
     mediaSession.setMediaButtonReceiver(null)
 
     // Create a MediaSessionConnector and attach the THEOplayer instance.

--- a/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
+++ b/android/src/main/java/com/theoplayer/media/MediaPlaybackService.kt
@@ -152,6 +152,10 @@ class MediaPlaybackService : Service() {
 
       // Set mediaSession active
       setActive(BuildConfig.EXTENSION_MEDIASESSION)
+
+      // Do not let MediaButtons restart the player when media session is not active.
+      // https://developer.android.com/media/legacy/media-buttons#restarting-inactive-mediasessions
+      mediaSession.setMediaButtonReceiver(null)
     }
   }
 


### PR DESCRIPTION
A fix for some crashes on Android related to the `MediaPlaybackService`, `MediaSession` and `MediaButtonReceiver` events.

in API 21 and later the `MediaSession` instance [captures all media buttons events](https://developer.android.com/media/legacy/media-buttons#mediabuttons-and-active-mediasessions) originating from remote controls, bluetooth head sets, ... and routes it to the player using our `MediaSessionConnector`.

If the app was closed (with back button), the service is destroyed and the mediaSessionConnector was set inactive. If any mediabutton event is then sent,  it is the `MediaButtonReceiver` that picks up the event (because the mediaSession is inactive), shown in [this diagram](https://developer.android.com/media/legacy/media-buttons#finding-a-media-session). The receiver will recreate the MediaPlaybackService and start it in the foreground. MediaPlaybackService now has 5 seconds to show a Notification. If this does not happen in time, a 

> Fatal Exception: android.app.RemoteServiceException$ForegroundServiceDidNotStartInTimeException

exception is thrown.

This behaviour [can be disabled](https://developer.android.com/media/legacy/media-buttons#restarting-inactive-mediasessions) by setting:

```
mediaSession.setMediaButtonReceiver(null)
```

The service will not be restarted, removing the chance for it to not be started in foreground within 5 seconds.