### PR TITLE
Feature/omid api change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [Unreleased]
 
 ### Fixed
 
 - Fixed a memory leak on iOS, caused by the wrapping ViewController that was keeping a strong reference to the THEOplayerRCTView.
 
+### Changed
+
+- **BREAKING**: Changed the `view` parameter in the `Omid` API from a ref container to a native node handle when registering "friendly" obstructions.
+
 ## [8.8.1] - 24-11-20
 
-### Fixed 
+### Fixed
 
 - Fixed build issue on tvOS caused by HomeIndicatorViewController
 

--- a/src/api/ads/Omid.ts
+++ b/src/api/ads/Omid.ts
@@ -1,5 +1,4 @@
-import React from 'react';
-import { View } from 'react-native';
+import { NodeHandle } from 'react-native';
 
 export enum OmidFriendlyObstructionPurpose {
   /**
@@ -26,8 +25,10 @@ export enum OmidFriendlyObstructionPurpose {
 export interface OmidFriendlyObstruction {
   /**
    * The View of the friendly obstruction.
+   *
+   * Use `React.findNodeHandle(component)` to get a component's native handle.
    */
-  view: React.RefObject<View>;
+  viewNodeHandle: NodeHandle | null;
 
   /**
    * The {@link OmidFriendlyObstructionPurpose} of the friendly obstruction.

--- a/src/internal/adapter/ads/THEOplayerNativeOmid.ts
+++ b/src/internal/adapter/ads/THEOplayerNativeOmid.ts
@@ -1,5 +1,5 @@
 import type { THEOplayerView } from 'react-native-theoplayer';
-import { findNodeHandle, NativeModules } from 'react-native';
+import { NativeModules } from 'react-native';
 import { Omid, OmidFriendlyObstruction } from '../../../api/ads/Omid';
 
 const NativeAdsModule = NativeModules.THEORCTAdsModule;
@@ -9,7 +9,7 @@ export class THEOplayerNativeOmid implements Omid {
 
   addFriendlyObstruction(obstruction: OmidFriendlyObstruction): void {
     NativeAdsModule.addFriendlyObstruction(this._player.nativeHandle, {
-      view: findNodeHandle(obstruction.view.current),
+      view: obstruction.viewNodeHandle,
       purpose: obstruction.purpose,
       reason: obstruction.reason,
     });


### PR DESCRIPTION
Change the OMID api to use the more convenient nodeHandle instead of a ref container when passing a view to be registered as "friendly' obstruction.