### PR TITLE
Allow configuration of ad load timeout for Google IMA plugin

### DIFF
--- a/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
+++ b/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
@@ -28,6 +28,7 @@ private const val PROP_RETRY_MAX_BACKOFF = "maximumBackoff"
 private const val PROP_CAST_CONFIGURATION = "cast"
 private const val PROP_ADS_CONFIGURATION = "ads"
 private const val PROP_IMA_CONFIGURATION = "ima"
+private const val PROP_IMA_AD_LOAD_TIMEOUT = "adLoadTimeout"
 private const val PROP_MEDIA_CONTROL = "mediaControl"
 private const val PROP_PPID = "ppid"
 private const val PROP_MAX_REDIRECTS = "maxRedirects"
@@ -169,10 +170,16 @@ class PlayerConfigAdapter(private val configProps: ReadableMap?) {
           }
         }
       }
-      // bitrate is configured under the ima config
+      // bitrate and timeout are configured under the ima config
       configProps?.getMap(PROP_ADS_CONFIGURATION)?.getMap(PROP_IMA_CONFIGURATION)?.run {
         if (hasKey(PROP_BITRATE)) {
           bitrateKbps = getInt(PROP_BITRATE)
+        }
+
+        // The time needs to be in milliseconds on android but seconds on ios.
+        // we unify the prop from javascript by multiplying it by 1000 here
+        if (hasKey(PROP_IMA_AD_LOAD_TIMEOUT)) {
+          setLoadVideoTimeout(getInt(PROP_IMA_AD_LOAD_TIMEOUT) * 1000)
         }
       }
     }

--- a/ios/ads/THEOplayerRCTView+Ads.swift
+++ b/ios/ads/THEOplayerRCTView+Ads.swift
@@ -57,6 +57,10 @@ extension THEOplayerRCTView {
             imaRenderSettings.mimeTypes = allowedMimeTypes
         }
         
+        if let adLoadTimeout = self.adsConfig.adsImaConfig.adLoadTimeout {
+            imaRenderSettings.loadVideoTimeout = adLoadTimeout
+        }
+        
         // setup integration
         let imaIntegration = GoogleIMAIntegrationFactory.createIntegration(on: player, with: imaSettings)
         imaIntegration.renderingSettings = imaRenderSettings

--- a/ios/ads/THEOplayerRCTView+AdsConfig.swift
+++ b/ios/ads/THEOplayerRCTView+AdsConfig.swift
@@ -21,14 +21,16 @@ struct AdsImaConfig {
     var autoPlayAdBreaks: Bool?
     var sessionID: String?
     var bitrate: Int
+    var adLoadTimeout: Int?
     
-    init(maxRedirects: UInt, enableDebugMode: Bool, ppid: String? = nil, featureFlags: [String : String]? = nil, autoPlayAdBreaks: Bool? = nil, sessionID: String? = nil, bitrate: Int? = -1) {
+    init(maxRedirects: UInt, enableDebugMode: Bool, ppid: String? = nil, featureFlags: [String : String]? = nil, autoPlayAdBreaks: Bool? = nil, sessionID: String? = nil, bitrate: Int? = -1, adLoadTimeout: Int? = nil) {
         self.maxRedirects = maxRedirects
         self.enableDebugMode = enableDebugMode
         self.ppid = ppid
         self.featureFlags = featureFlags
         self.autoPlayAdBreaks = autoPlayAdBreaks
         self.sessionID = sessionID
+        self.adLoadTimeout = adLoadTimeout
 #if canImport(THEOplayerGoogleIMAIntegration)
         self.bitrate = bitrate ?? kIMAAutodetectBitrate
 #else
@@ -66,6 +68,9 @@ extension THEOplayerRCTView {
                 }
                 if let bitrate = adsImaConfig["bitrate"] as? Int {
                     self.adsConfig.adsImaConfig.bitrate = bitrate
+                }
+                if let adLoadTimeout = adsImaConfig["adLoadTimeout"] as? Int {
+                    self.adsConfig.adsImaConfig.adLoadTimeout = adLoadTimeout
                 }
             }
         }

--- a/ios/ads/THEOplayerRCTView+AdsConfig.swift
+++ b/ios/ads/THEOplayerRCTView+AdsConfig.swift
@@ -21,9 +21,9 @@ struct AdsImaConfig {
     var autoPlayAdBreaks: Bool?
     var sessionID: String?
     var bitrate: Int
-    var adLoadTimeout: Int?
+    var adLoadTimeout: TimeInterval?
     
-    init(maxRedirects: UInt, enableDebugMode: Bool, ppid: String? = nil, featureFlags: [String : String]? = nil, autoPlayAdBreaks: Bool? = nil, sessionID: String? = nil, bitrate: Int? = -1, adLoadTimeout: Int? = nil) {
+    init(maxRedirects: UInt, enableDebugMode: Bool, ppid: String? = nil, featureFlags: [String : String]? = nil, autoPlayAdBreaks: Bool? = nil, sessionID: String? = nil, bitrate: Int? = -1, adLoadTimeout: TimeInterval? = nil) {
         self.maxRedirects = maxRedirects
         self.enableDebugMode = enableDebugMode
         self.ppid = ppid
@@ -69,7 +69,7 @@ extension THEOplayerRCTView {
                 if let bitrate = adsImaConfig["bitrate"] as? Int {
                     self.adsConfig.adsImaConfig.bitrate = bitrate
                 }
-                if let adLoadTimeout = adsImaConfig["adLoadTimeout"] as? Int {
+                if let adLoadTimeout = adsImaConfig["adLoadTimeout"] as? TimeInterval {
                     self.adsConfig.adsImaConfig.adLoadTimeout = adLoadTimeout
                 }
             }

--- a/src/api/ads/GoogleImaConfiguration.ts
+++ b/src/api/ads/GoogleImaConfiguration.ts
@@ -52,4 +52,10 @@ export interface GoogleImaConfiguration {
    * @defaultValue `-1`
    */
   bitrate?: number;
+
+  /**
+   * The amount of time that the SDK will wait before moving onto the next ad for loading. 
+   * This value will be specified in seconds. 
+   */
+  adLoadTimeout?: number;
 }


### PR DESCRIPTION
Enable setting a custom ad load timeout for the Google IMA plugin via the ad configuration. By default, IMA uses an 8-second timeout if no option is provided, but this can now be adjusted as needed.