### PR TITLE
Bugfix/texttrack with initial cues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed a memory leak on iOS, where the presentationModeManager was holding a strong reference to the fullscreen's target and return views
 - Fixed an issue on iOS where the destruction of the THEOplayerView was not always propagated correctly over the iOS Bridge, resulting in an occasional memory leak.
+- Fixed an issue where, when requesting a text track's cues, the time properties would sometimes be in seconds instead of milliseconds.
 
 ## [8.11.1] - 24-12-18
 

--- a/src/internal/adapter/WebEventForwarder.ts
+++ b/src/internal/adapter/WebEventForwarder.ts
@@ -18,7 +18,7 @@ import type {
   VolumeChangeEvent as NativeVolumeChangeEvent,
   DimensionChangeEvent as NativeDimensionChangeEvent,
 } from 'theoplayer';
-import type { AdEvent, MediaTrack, TextTrack, TimeRange } from 'react-native-theoplayer';
+import type { AdEvent, MediaTrack, TimeRange } from 'react-native-theoplayer';
 import {
   AdEventType,
   CastState,
@@ -267,7 +267,7 @@ export class WebEventForwarder {
     track.addEventListener('removecue', this.onRemoveTextTrackCue(track));
     track.addEventListener('entercue', this.onEnterTextTrackCue(track));
     track.addEventListener('exitcue', this.onExitTextTrackCue(track));
-    this._facade.dispatchEvent(new DefaultTextTrackListEvent(TrackListEventType.ADD_TRACK, track as TextTrack));
+    this._facade.dispatchEvent(new DefaultTextTrackListEvent(TrackListEventType.ADD_TRACK, fromNativeTextTrack(track)));
   };
 
   private readonly onRemoveTextTrack = (event: RemoveTrackEvent) => {
@@ -276,11 +276,11 @@ export class WebEventForwarder {
     track.removeEventListener('removecue', this.onRemoveTextTrackCue(track));
     track.removeEventListener('entercue', this.onEnterTextTrackCue(track));
     track.removeEventListener('exitcue', this.onExitTextTrackCue(track));
-    this._facade.dispatchEvent(new DefaultTextTrackListEvent(TrackListEventType.REMOVE_TRACK, track as NativeTextTrack as TextTrack));
+    this._facade.dispatchEvent(new DefaultTextTrackListEvent(TrackListEventType.REMOVE_TRACK, fromNativeTextTrack(track)));
   };
 
   private readonly onChangeTextTrack = (event: TrackChangeEvent) => {
-    this._facade.dispatchEvent(new DefaultTextTrackListEvent(TrackListEventType.CHANGE_TRACK, event.track as NativeTextTrack as TextTrack));
+    this._facade.dispatchEvent(new DefaultTextTrackListEvent(TrackListEventType.CHANGE_TRACK, fromNativeTextTrack(event.track as NativeTextTrack)));
   };
 
   private readonly onAddAudioTrack = (event: AddTrackEvent) => {


### PR DESCRIPTION
Fixed an issue where `startTime` and `endTime` would be in seconds instead of milliseconds when requesting the cues. In practice this would mostly effect thumbnail metadata cues.