### PR TITLE
Bugfix/fix rare nullpointer exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed a memory leak on iOS, where the presentationModeManager was holding a strong reference to the fullscreen's target and return views
 - Fixed an issue on iOS where the destruction of the THEOplayerView was not always propagated correctly over the iOS Bridge, resulting in an occasional memory leak.
 - Fixed an issue where, when requesting a text track's cues, the time properties would sometimes be in seconds instead of milliseconds.
+- Fixed a rare crash due to a `java.lang.NullPointerException` when creating the THEOplayerView.
 
 ## [8.11.1] - 24-12-18
 

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -205,7 +205,7 @@ class ReactTHEOplayerContext private constructor(
   }
 
   private fun initializePlayerView() {
-    playerView = object : THEOplayerView(reactContext.currentActivity!!, configAdapter.playerConfig()) {
+    playerView = object : THEOplayerView(reactContext, configAdapter.playerConfig()) {
       private fun measureAndLayout() {
         measure(
           MeasureSpec.makeMeasureSpec(measuredWidth, MeasureSpec.EXACTLY),


### PR DESCRIPTION
Fixed a `java.lang.NullPointerException` by using the `reactContext` instead of the nullable `reactContext.currentActivity`.