### PR TITLE
Set concurrent-ruby version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,4 @@ gem "webrick", "~> 1.8"
 gem 'cocoapods', '>= 1.13', '< 1.15'
 gem 'activesupport', '>= 6.1.7.5', '< 7.1.0'
 gem 'xcodeproj', '< 1.26.0'
+gem 'concurrent-ruby', '1.3.4'


### PR DESCRIPTION
concurrent-ruby v1.3.5 has removed the dependency on logger, so pin to v1.3.4

The alternative is upgrading to rails 7.1 apparently:
https://stackoverflow.com/a/79361034/2352774