### PR TITLE
bugfix/playbackrate-notification-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue on iOS where the `currentTime` on `NowPlayingInfoCenter` would go out of sync or reset when changing playback rate.
+
 ## [8.13.1] - 25-01-27
 
 ### Fixed

--- a/ios/backgroundAudio/THEOplayerRCTNowPlayingManager.swift
+++ b/ios/backgroundAudio/THEOplayerRCTNowPlayingManager.swift
@@ -241,7 +241,8 @@ class THEOplayerRCTNowPlayingManager {
         self.rateChangeListener = player.addEventListener(type: PlayerEventTypes.RATE_CHANGE) { [weak self, weak player] event in
             if let welf = self,
                let wplayer = player {
-                welf.nowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] = NSNumber(value: wplayer.playbackRate)
+                welf.updatePlaybackRate(wplayer.playbackRate)
+                welf.updateCurrentTime(wplayer.currentTime)
                 if DEBUG_NOWINFO { PrintUtils.printLog(logText: "[NATIVE] RATE_CHANGE: Updating playbackRate on NowPlayingInfoCenter...") }
                 welf.processNowPlayingToInfoCenter()
             }


### PR DESCRIPTION
This PR fixes an issue on iOS where the `currentTime` on `NowPlayingInfoCenter` would go out of sync or reset when changing playback rate. For reference, see: THEOSD-14872.