### PR TITLE
Bugfix/web fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Transitioning to `fullscreen` presentation mode on Web platforms now puts only the `THEOplayerView` element and its child elements, such as the UI, in fullscreen. Previously, the whole page would transition to fullscreen.
+
+### Fixed
+
+- Fixed an issue on iOS Safari where transitioning to `fullscreen` presentation mode would not work.
+- Fixed an issue on Web where `presentationmodechange` events would sometimes be dispatched more than once.
+
 ## [8.14.0] - 25-02-10
 
 ### Added

--- a/src/api/config/PlayerConfiguration.ts
+++ b/src/api/config/PlayerConfiguration.ts
@@ -63,6 +63,8 @@ export interface PlayerConfiguration {
    *
    * @remarks
    * <br/> - This parameter only applies to Web platforms.
+   *
+   * @deprecated: Use the OpenVideoUI package {@link https://github.com/THEOplayer/react-native-theoplayer-ui}.
    */
   readonly chromeless?: boolean;
 

--- a/src/internal/THEOplayerView.web.tsx
+++ b/src/internal/THEOplayerView.web.tsx
@@ -66,14 +66,17 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
 
   const chromeless = config?.chromeless === undefined || config?.chromeless;
   return (
-    <>
+    // Note: display: contents causes an element's children to appear as if they were direct children of the element's parent,
+    // ignoring the element itself.
+    // It's necessary to make sure we do not interfere with the IMA container
+    <div id={'theoplayer-root-container'} style={{ display: 'contents' }}>
       <div
         ref={container}
         style={styles.container}
         className={chromeless ? 'theoplayer-container' : 'theoplayer-container video-js theoplayer-skin'}
       />
       {children}
-    </>
+    </div>
   );
 }
 

--- a/src/internal/adapter/WebEventForwarder.ts
+++ b/src/internal/adapter/WebEventForwarder.ts
@@ -88,7 +88,6 @@ export class WebEventForwarder {
     this._player.addEventListener('segmentnotfound', this.onSegmentNotFound);
     this._player.addEventListener('volumechange', this.onVolumeChangeEvent);
     this._player.addEventListener('dimensionchange', this.onDimensionChange);
-    this._player.presentation.addEventListener('presentationmodechange', this.onPresentationModeChange);
 
     this._player.textTracks.addEventListener('addtrack', this.onAddTextTrack);
     this._player.textTracks.addEventListener('removetrack', this.onRemoveTextTrack);

--- a/src/internal/adapter/web/WebPresentationModeManager.ts
+++ b/src/internal/adapter/web/WebPresentationModeManager.ts
@@ -10,12 +10,12 @@ export class WebPresentationModeManager {
   private readonly _player: ChromelessPlayer;
   private _presentationMode: PresentationMode = PresentationMode.inline;
   private _eventForwarder: DefaultEventDispatcher<PlayerEventMap>;
-  private _didPrepare: boolean = false;
 
   constructor(player: ChromelessPlayer, eventForwarder: DefaultEventDispatcher<PlayerEventMap>) {
     this._player = player;
     this._eventForwarder = eventForwarder;
     this._player.presentation.addEventListener('presentationmodechange', this.updatePresentationMode);
+    this.maybePrepareForPresentationModeChanges();
   }
 
   get presentationMode(): PresentationMode {
@@ -27,8 +27,6 @@ export class WebPresentationModeManager {
       // Ignore if presentationMode did not change.
       return;
     }
-
-    this.maybePrepareForPresentationModeChanges();
 
     if (fullscreenAPI !== undefined) {
       // If the browser supports the fullscreenAPI, put the element that encloses the player & UI in fullscreen.
@@ -60,11 +58,6 @@ export class WebPresentationModeManager {
   }
 
   private maybePrepareForPresentationModeChanges() {
-    if (this._didPrepare) {
-      return;
-    }
-    this._didPrepare = true;
-
     // listen for fullscreen updates on document
     if (fullscreenAPI !== undefined) {
       document.addEventListener(fullscreenAPI.fullscreenchange_, this.updatePresentationMode);

--- a/src/internal/adapter/web/WebPresentationModeManager.ts
+++ b/src/internal/adapter/web/WebPresentationModeManager.ts
@@ -10,6 +10,7 @@ export class WebPresentationModeManager {
   private readonly _player: ChromelessPlayer;
   private _presentationMode: PresentationMode = PresentationMode.inline;
   private _eventForwarder: DefaultEventDispatcher<PlayerEventMap>;
+  private _didPrepare: boolean = false;
 
   constructor(player: ChromelessPlayer, eventForwarder: DefaultEventDispatcher<PlayerEventMap>) {
     this._player = player;
@@ -27,7 +28,7 @@ export class WebPresentationModeManager {
       return;
     }
 
-    this.prepareForPresentationModeChanges();
+    this.maybePrepareForPresentationModeChanges();
 
     if (fullscreenAPI !== undefined) {
       // If the browser supports the fullscreenAPI, put the element that encloses the player & UI in fullscreen.
@@ -58,7 +59,12 @@ export class WebPresentationModeManager {
     }
   }
 
-  private prepareForPresentationModeChanges() {
+  private maybePrepareForPresentationModeChanges() {
+    if (this._didPrepare) {
+      return;
+    }
+    this._didPrepare = true;
+
     // listen for fullscreen updates on document
     if (fullscreenAPI !== undefined) {
       document.addEventListener(fullscreenAPI.fullscreenchange_, this.updatePresentationMode);

--- a/src/internal/adapter/web/WebPresentationModeManager.ts
+++ b/src/internal/adapter/web/WebPresentationModeManager.ts
@@ -23,32 +23,27 @@ export class WebPresentationModeManager {
 
   set presentationMode(presentationMode: PresentationMode) {
     if (presentationMode === this._presentationMode) {
+      // Ignore if presentationMode did not change.
       return;
     }
 
     this.prepareForPresentationModeChanges();
 
     if (fullscreenAPI !== undefined) {
-      // All other browsers
+      // If the browser supports the fullscreenAPI, put the element that encloses the player & UI in fullscreen.
       if (presentationMode === PresentationMode.fullscreen) {
-        const appElement = document.getElementById('app') ?? document.getElementById('root');
+        const appElement = document.getElementById('theoplayer-root-container');
         if (appElement !== null) {
-          const promise = appElement[fullscreenAPI.requestFullscreen_]();
-          if (promise && promise.then) {
-            promise.then(noOp, noOp);
-          }
+          appElement[fullscreenAPI.requestFullscreen_]()?.then?.(noOp, noOp);
         }
       } else if (presentationMode === PresentationMode.pip) {
         this._player.presentation.requestMode('native-picture-in-picture');
       } else {
         if (this._presentationMode === PresentationMode.fullscreen) {
-          const promise = document[fullscreenAPI.exitFullscreen_]();
-          if (promise && promise.then) {
-            promise.then(noOp, noOp);
-          }
+          document[fullscreenAPI.exitFullscreen_]()?.then?.(noOp, noOp);
         }
         if (this._presentationMode === PresentationMode.pip) {
-          void document.exitPictureInPicture();
+          document.exitPictureInPicture().then(noOp, noOp);
         }
       }
     } else {

--- a/src/internal/adapter/web/WebPresentationModeManager.ts
+++ b/src/internal/adapter/web/WebPresentationModeManager.ts
@@ -44,7 +44,7 @@ export class WebPresentationModeManager {
           document[fullscreenAPI.exitFullscreen_]()?.then?.(noOp, noOp);
         }
         if (this._presentationMode === PresentationMode.pip) {
-          document.exitPictureInPicture().then(noOp, noOp);
+          this._player.presentation.requestMode(PresentationMode.inline);
         }
       }
     } else {


### PR DESCRIPTION
Several changes to presentation mode changes on web:

- Introduced a parent `theoplayer-root-container` above the player + UI-container, which is used to transition only these player-elements to fullscreen (if the platform allows it).
- Let the player SDK handle fullscreen transitioning on iOS Safari instead of looking for a correct video element ourselves,
- Duplicate `presentationmodechange` events were being dispatched.
- Only add listeners to the fullscreen element once.