### PR TITLE
Bugfix/android fullscreen layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added the THEOads API for Web.
 - Added `retrievePodIdURI` property to `TheoAdsDescription` for Android and iOS.
 
+### Changed
+
+- Changed the fullscreen screen dimension calculation on Android, taking into account edgeToEdge layouts.
+
 ## [8.16.0] - 25-02-28
 
 ### Changed
@@ -43,6 +47,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue on iOS where `hlsDateRange` was not passed from RN towards iOS native
 - Fixed an issue on Android, where the player would sometimes not initialise correctly in case New Architecture was not being used, resulting in a black screen.
 - Fixed an issue on iOS Safari browsers, where the `presentationmodechange` event would not be dispatched when entering or exiting fullscreen.
+
 
 ## [8.15.0] - 25-02-12
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,8 +59,9 @@ android {
     def TimeUpdateRate = "com.theoplayer.TimeUpdateRate"
     buildConfigField TimeUpdateRate, "TIMEUPDATE_RATE", safeExtGet('THEOplayer_timeUpdateRate', "${TimeUpdateRate}.UNLIMITED")
 
-    // Optionally re-parent player view on fullscreen event
+    // Optionally re-parent player view on fullscreen or PiP event
     buildConfigField "boolean", "REPARENT_ON_FULLSCREEN", "${safeExtGet('THEOplayer_reparent_on_fullscreen', 'true')}"
+    buildConfigField "boolean", "REPARENT_ON_PIP", "${safeExtGet('THEOplayer_reparent_on_PiP', 'true')}"
 
     // Optionally log events to logcat
     buildConfigField "boolean", "LOG_PLAYER_EVENTS", "${safeExtGet('THEOplayer_logPlayerEvents', 'false')}"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -61,7 +61,7 @@ android {
 
     // Optionally re-parent player view on fullscreen or PiP event
     buildConfigField "boolean", "REPARENT_ON_FULLSCREEN", "${safeExtGet('THEOplayer_reparent_on_fullscreen', 'true')}"
-    buildConfigField "boolean", "REPARENT_ON_PIP", "${safeExtGet('THEOplayer_reparent_on_PiP', 'true')}"
+    buildConfigField "boolean", "REPARENT_ON_PIP", "${safeExtGet('THEOplayer_reparent_on_PiP', 'false')}"
 
     // Optionally log events to logcat
     buildConfigField "boolean", "LOG_PLAYER_EVENTS", "${safeExtGet('THEOplayer_logPlayerEvents', 'false')}"

--- a/android/src/main/java/com/theoplayer/player/PlayerModule.kt
+++ b/android/src/main/java/com/theoplayer/player/PlayerModule.kt
@@ -263,4 +263,17 @@ class PlayerModule(context: ReactApplicationContext) : ReactContextBaseJavaModul
       )
     }
   }
+
+  @ReactMethod(isBlockingSynchronousMethod = true)
+  fun getUsableScreenDimensions(): WritableMap {
+    // Pass the dimensions of the top-most View in the view hierarchy.
+    val topView = reactApplicationContext.currentActivity?.window?.decorView?.rootView
+    reactApplicationContext.resources.displayMetrics.also {
+      val density = it.density
+      return Arguments.createMap().apply {
+        putDouble("width", (topView?.width ?: 0) / density.toDouble())
+        putDouble("height", (topView?.height ?: 0) / density.toDouble())
+      }
+    }
+  }
 }

--- a/android/src/main/java/com/theoplayer/presentation/FullscreenLayoutObserver.kt
+++ b/android/src/main/java/com/theoplayer/presentation/FullscreenLayoutObserver.kt
@@ -1,7 +1,10 @@
 package com.theoplayer.presentation
 
+import android.util.Log
 import android.view.ViewTreeObserver
 import com.facebook.react.views.view.ReactViewGroup
+
+private val TAG = "FSLayoutObserver"
 
 /**
  * FullScreenLayoutObserver makes sure that the React Native view does not get the layout
@@ -10,8 +13,13 @@ import com.facebook.react.views.view.ReactViewGroup
  */
 class FullScreenLayoutObserver {
   private var globalLayoutListener: ViewTreeObserver.OnGlobalLayoutListener? = null
+  private var attached: ReactViewGroup? = null
 
   fun attach(viewGroup: ReactViewGroup?) {
+    if (attached != null) {
+      Log.w(TAG, "A previously attached ViewGroup was not properly detached.")
+    }
+
     viewGroup?.let {
       globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
         it.post {
@@ -19,11 +27,13 @@ class FullScreenLayoutObserver {
         }
       }
       it.viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)
+      attached = viewGroup
     }
   }
 
-  fun remove(viewGroup: ReactViewGroup?) {
-    viewGroup?.viewTreeObserver?.removeOnGlobalLayoutListener(globalLayoutListener)
+  fun remove() {
+    attached?.viewTreeObserver?.removeOnGlobalLayoutListener(globalLayoutListener)
+    attached = null
     globalLayoutListener = null
   }
 }

--- a/android/src/main/java/com/theoplayer/presentation/FullscreenLayoutObserver.kt
+++ b/android/src/main/java/com/theoplayer/presentation/FullscreenLayoutObserver.kt
@@ -1,0 +1,29 @@
+package com.theoplayer.presentation
+
+import android.view.ViewTreeObserver
+import com.facebook.react.views.view.ReactViewGroup
+
+/**
+ * FullScreenLayoutObserver makes sure that the React Native view does not get the layout
+ * defined in React-Native during fullscreen presentation mode. We want to enforce fullscreen
+ * position & size.
+ */
+class FullScreenLayoutObserver {
+  private var globalLayoutListener: ViewTreeObserver.OnGlobalLayoutListener? = null
+
+  fun attach(viewGroup: ReactViewGroup?) {
+    viewGroup?.let {
+      globalLayoutListener = ViewTreeObserver.OnGlobalLayoutListener {
+        it.post {
+          it.layout(0, 0, viewGroup.width, viewGroup.height)
+        }
+      }
+      it.viewTreeObserver.addOnGlobalLayoutListener(globalLayoutListener)
+    }
+  }
+
+  fun remove(viewGroup: ReactViewGroup?) {
+    viewGroup?.viewTreeObserver?.removeOnGlobalLayoutListener(globalLayoutListener)
+    globalLayoutListener = null
+  }
+}

--- a/android/src/main/java/com/theoplayer/presentation/PipUtils.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PipUtils.kt
@@ -12,9 +12,6 @@ import android.graphics.Rect
 import android.graphics.drawable.Icon
 import android.os.Build
 import android.util.Rational
-import android.view.SurfaceView
-import android.view.TextureView
-import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.RequiresApi
 import com.facebook.react.uimanager.ThemedReactContext
@@ -108,7 +105,8 @@ class PipUtils(
     }
     try {
       reactContext.currentActivity?.unregisterReceiver(broadcastReceiver)
-    } catch (ignore: IllegalArgumentException) { /*ignore*/}
+    } catch (ignore: IllegalArgumentException) { /*ignore*/
+    }
     enabled = false
   }
 
@@ -189,17 +187,13 @@ class PipUtils(
   }
 
   private fun getContentViewRect(view: ViewGroup): Rect? {
-    for (i in 0 until view.childCount) {
-      val child: View = view.getChildAt(i)
-      if (child is ViewGroup) {
-        return getContentViewRect(child)
-      } else if (child as? SurfaceView != null || child as? TextureView != null) {
-        val visibleRect = Rect()
-        child.getGlobalVisibleRect(visibleRect)
-        return visibleRect
+    return view.findViewById<ViewGroup>(com.theoplayer.android.R.id.theo_content_player_container)
+      ?.getChildAt(0) // AspectRatioView
+      ?.run {
+        Rect().apply {
+          getGlobalVisibleRect(this)
+        }
       }
-    }
-    return null
   }
 
   @RequiresApi(Build.VERSION_CODES.O)

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -8,6 +8,8 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.os.Build
+import android.os.Handler
+import android.os.Looper
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewParent
@@ -17,7 +19,6 @@ import androidx.core.view.WindowInsetsControllerCompat
 import androidx.core.view.children
 import androidx.lifecycle.Lifecycle
 import com.facebook.react.ReactRootView
-import com.facebook.react.runtime.ReactSurfaceView
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.views.view.ReactViewGroup
 import com.theoplayer.BuildConfig
@@ -26,6 +27,8 @@ import com.theoplayer.ReactTHEOplayerContext
 import com.theoplayer.android.api.error.ErrorCode
 import com.theoplayer.android.api.error.THEOplayerException
 import com.theoplayer.android.api.player.PresentationMode
+
+private const val FULLSCREEN_EVENT_DELAY: Long = 150
 
 @SuppressLint("UnspecifiedRegisterReceiverFlag")
 class PresentationManager(
@@ -229,7 +232,10 @@ class PresentationManager(
         hide(WindowInsetsCompat.Type.systemBars())
       }
 
-      updatePresentationMode(PresentationMode.FULLSCREEN)
+      // Delay the event making sure it does not arrive before animations ended.
+      Handler(Looper.getMainLooper()).postDelayed({
+        updatePresentationMode(PresentationMode.FULLSCREEN)
+      }, FULLSCREEN_EVENT_DELAY)
 
       if (BuildConfig.REPARENT_ON_FULLSCREEN) {
         reparentPlayerToRoot()

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -14,6 +14,7 @@ import android.view.ViewParent
 import androidx.activity.ComponentActivity
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.core.view.children
 import androidx.lifecycle.Lifecycle
 import com.facebook.react.ReactRootView
 import com.facebook.react.runtime.ReactSurfaceView
@@ -35,9 +36,10 @@ class PresentationManager(
   private var supportsPip = false
   private var onUserLeaveHintReceiver: BroadcastReceiver? = null
   private var onPictureInPictureModeChanged: BroadcastReceiver? = null
-  private var playerGroupParentNode: ViewGroup? = null
-  private var playerGroupChildIndex: Int? = null
   private val pipUtils: PipUtils = PipUtils(viewCtx, reactContext)
+  private val playerGroupRestoreOptions by lazy {
+    PlayerGroupRestoreOptions()
+  }
 
   var currentPresentationMode: PresentationMode = PresentationMode.INLINE
     private set
@@ -146,6 +148,9 @@ class PresentationManager(
     try {
       pipUtils.enable()
       reactContext.currentActivity?.enterPictureInPictureMode(pipUtils.getPipParams())
+      if (BuildConfig.REPARENT_ON_PIP) {
+        reparentPlayerToRoot()
+      }
     } catch (_: Exception) {
       onPipError()
     }
@@ -169,6 +174,9 @@ class PresentationManager(
       } else {
         PresentationModeChangePipContext.RESTORED
       }
+    if (BuildConfig.REPARENT_ON_PIP) {
+      reparentPlayerToOriginal()
+    }
     updatePresentationMode(PresentationMode.INLINE, PresentationModeChangeContext(pipCtx))
     pipUtils.disable()
   }
@@ -209,30 +217,14 @@ class PresentationManager(
     val activity = reactContext.currentActivity ?: return
     val window = activity.window
 
-    // Get the player's ReactViewGroup parent, which contains THEOplayerView and its children (typically the UI).
-    val reactPlayerGroup: ReactViewGroup? = getClosestParentOfType(this.viewCtx.playerView)
-
-    // Get ReactNative's root node or the render hierarchy
-    val root: ReactRootView? = getClosestParentOfType(reactPlayerGroup)
-
     if (fullscreen) {
       WindowInsetsControllerCompat(window, window.decorView).apply {
         systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
       }.hide(WindowInsetsCompat.Type.systemBars())
       updatePresentationMode(PresentationMode.FULLSCREEN)
 
-      if (!BuildConfig.REPARENT_ON_FULLSCREEN) {
-        return
-      }
-      playerGroupParentNode = if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-        reactPlayerGroup?.parent as? ReactSurfaceView?
-      } else {
-        reactPlayerGroup?.parent as? ReactViewGroup?
-      }?.also { parent ->
-        playerGroupChildIndex = parent.indexOfChild(reactPlayerGroup)
-        // Re-parent the playerViewGroup to the root node
-        parent.removeView(reactPlayerGroup)
-        root?.addView(reactPlayerGroup)
+      if (BuildConfig.REPARENT_ON_FULLSCREEN) {
+        reparentPlayerToRoot()
       }
     } else {
       WindowInsetsControllerCompat(window, window.decorView).show(
@@ -240,18 +232,47 @@ class PresentationManager(
       )
       updatePresentationMode(PresentationMode.INLINE)
 
-      if (!BuildConfig.REPARENT_ON_FULLSCREEN) {
-        return
-      }
-      root?.run {
-        // Re-parent the playerViewGroup from the root node to its original parent
-        removeView(reactPlayerGroup)
-        playerGroupParentNode?.addView(reactPlayerGroup, playerGroupChildIndex ?: 0)
-        playerGroupParentNode = null
-        playerGroupChildIndex = null
+      if (BuildConfig.REPARENT_ON_FULLSCREEN) {
+        reparentPlayerToOriginal()
       }
     }
   }
+
+  // region Re-parent playerViewGroup logic
+  private val reactPlayerGroup: ReactViewGroup?
+    get() = viewCtx.playerView.getClosestParentOfType()
+  private val rootView: ReactRootView?
+    get() {
+      val activity = reactContext.currentActivity ?: return null
+      // Try to search in parents and as a fallback option from root to bottom using depth-first order
+      return reactPlayerGroup?.getClosestParentOfType()
+        ?: (activity.window.decorView.rootView as? ViewGroup)
+          ?.getClosestParentOfType(false)
+    }
+
+  private fun reparentPlayerToRoot() {
+    playerGroupRestoreOptions.parentNode = if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      reactPlayerGroup?.parent as? ReactSurfaceView?
+    } else {
+      reactPlayerGroup?.parent as? ReactViewGroup?
+    }?.also { parent ->
+      playerGroupRestoreOptions.childIndex = parent.indexOfChild(reactPlayerGroup)
+
+      // Re-parent the playerViewGroup to the root node
+      parent.removeView(reactPlayerGroup)
+      rootView?.addView(reactPlayerGroup)
+    }
+  }
+
+  private fun reparentPlayerToOriginal() {
+    rootView?.run {
+      // Re-parent the playerViewGroup from the root node to its original parent
+      removeView(reactPlayerGroup)
+      playerGroupRestoreOptions.parentNode?.addView(reactPlayerGroup, playerGroupRestoreOptions.childIndex ?: 0)
+      playerGroupRestoreOptions.reset()
+    }
+  }
+// endregion
 
   private fun updatePresentationMode(
     presentationMode: PresentationMode,
@@ -279,10 +300,41 @@ class PresentationManager(
   }
 }
 
-inline fun <reified T : View> getClosestParentOfType(view: View?): T? {
-  var parent: ViewParent? = view?.parent
-  while (parent != null && parent !is T) {
-    parent = parent.parent
+inline fun <reified T : View> ViewGroup.getClosestParentOfType(upward: Boolean = true): T? {
+  if (upward) {
+    // Search in the parent views of `this` view up to the root
+    var parent: ViewParent? = parent
+    while (parent != null && parent !is T) {
+      parent = parent.parent
+    }
+    return parent as? T
+  } else {
+    // Search in the children collection.
+    val viewStack = ArrayDeque(children.toList())
+    // Use Stack/LIFO instead of recursion
+    while (viewStack.isNotEmpty()) {
+      when (val view = viewStack.removeAt(0)) {
+        is T -> {
+          return view
+        }
+
+        is ViewGroup -> {
+          // Filling LIFO with all children of the ViewGroup: depth-first order
+          viewStack.addAll(0, view.children.toList())
+        }
+      }
+    }
+    // Found nothing
+    return null
   }
-  return parent as? T
+}
+
+private class PlayerGroupRestoreOptions {
+  var childIndex: Int? = null
+  var parentNode: ViewGroup? = null
+
+  fun reset() {
+    parentNode = null
+    childIndex = null
+  }
 }

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -102,6 +102,7 @@ class PresentationManager(
     try {
       reactContext.currentActivity?.unregisterReceiver(onUserLeaveHintReceiver)
       reactContext.currentActivity?.unregisterReceiver(onPictureInPictureModeChanged)
+      fullScreenLayoutObserver.remove()
       pipUtils.destroy()
     } catch (ignore: Exception) {
     }
@@ -282,7 +283,7 @@ class PresentationManager(
       playerGroupRestoreOptions.reset()
 
       // Remove forced layout observer
-      fullScreenLayoutObserver.remove(reactPlayerGroup)
+      fullScreenLayoutObserver.remove()
     }
   }
 // endregion

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -8,8 +8,6 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.os.Build
-import android.os.Handler
-import android.os.Looper
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewParent
@@ -27,8 +25,6 @@ import com.theoplayer.ReactTHEOplayerContext
 import com.theoplayer.android.api.error.ErrorCode
 import com.theoplayer.android.api.error.THEOplayerException
 import com.theoplayer.android.api.player.PresentationMode
-
-private const val FULLSCREEN_EVENT_DELAY: Long = 150
 
 @SuppressLint("UnspecifiedRegisterReceiverFlag")
 class PresentationManager(
@@ -233,9 +229,9 @@ class PresentationManager(
       }
 
       // Delay the event making sure it does not arrive before animations ended.
-      Handler(Looper.getMainLooper()).postDelayed({
+      viewCtx.playerView.postOnAnimation {
         updatePresentationMode(PresentationMode.FULLSCREEN)
-      }, FULLSCREEN_EVENT_DELAY)
+      }
 
       if (BuildConfig.REPARENT_ON_FULLSCREEN) {
         reparentPlayerToRoot()

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -219,9 +219,15 @@ class PresentationManager(
     val window = activity.window
 
     if (fullscreen) {
+      // Hide system bars for immersive mode.
+      // {@link https://developer.android.com/develop/ui/views/layout/immersive}
       WindowInsetsControllerCompat(window, window.decorView).apply {
+        // Reveal hidden system bars on any system gestures.
         systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-      }.hide(WindowInsetsCompat.Type.systemBars())
+        // Hide all system bars.
+        hide(WindowInsetsCompat.Type.systemBars())
+      }
+
       updatePresentationMode(PresentationMode.FULLSCREEN)
 
       if (BuildConfig.REPARENT_ON_FULLSCREEN) {

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -37,6 +37,7 @@ class PresentationManager(
   private var onUserLeaveHintReceiver: BroadcastReceiver? = null
   private var onPictureInPictureModeChanged: BroadcastReceiver? = null
   private val pipUtils: PipUtils = PipUtils(viewCtx, reactContext)
+  private val fullScreenLayoutObserver = FullScreenLayoutObserver()
   private val playerGroupRestoreOptions by lazy {
     PlayerGroupRestoreOptions()
   }
@@ -261,6 +262,9 @@ class PresentationManager(
       // Re-parent the playerViewGroup to the root node
       parent.removeView(reactPlayerGroup)
       rootView?.addView(reactPlayerGroup)
+
+      // Attach an observer that overrides the react-native lay-out and forces fullscreen.
+      fullScreenLayoutObserver.attach(reactPlayerGroup)
     }
   }
 
@@ -270,6 +274,9 @@ class PresentationManager(
       removeView(reactPlayerGroup)
       playerGroupRestoreOptions.parentNode?.addView(reactPlayerGroup, playerGroupRestoreOptions.childIndex ?: 0)
       playerGroupRestoreOptions.reset()
+
+      // Remove forced layout observer
+      fullScreenLayoutObserver.remove(reactPlayerGroup)
     }
   }
 // endregion

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -118,6 +118,8 @@ dependencies {
     // The version of react-native is set by the React Native Gradle Plugin
     implementation("com.facebook.react:react-android")
 
+    implementation("androidx.activity:activity-ktx:1.9.3")
+
     if (hermesEnabled.toBoolean()) {
         implementation("com.facebook.react:hermes-android")
     } else {

--- a/example/android/app/src/main/java/com/reactnativetheoplayer/MainActivity.kt
+++ b/example/android/app/src/main/java/com/reactnativetheoplayer/MainActivity.kt
@@ -6,6 +6,7 @@ import android.content.res.Configuration
 import android.media.AudioManager
 import android.os.Build
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import com.facebook.react.ReactActivity
 import com.facebook.react.ReactActivityDelegate
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
@@ -14,7 +15,16 @@ import com.google.android.gms.cast.framework.CastContext
 
 open class MainActivity : ReactActivity() {
   public override fun onCreate(bundle: Bundle?) {
+    // Edge-to-edge is enforced on Android 15 so that the system bars are transparent or
+    // translucent by default. On earlier versions of Android, remove opaque system bars opaque by
+    // calling enableEdgeToEdge().
+    // On Android 15 and later devices, or after calling enableEdgeToEdge(), gesture navigation is
+    // transparent by default. Three-button navigation is translucent by default or opaque if it is
+    // inside the taskbar on large screen device.
+    // (@link https://developer.android.com/design/ui/mobile/guides/foundations/system-bars#immersive-mode}
+    enableEdgeToEdge()
     super.onCreate(bundle)
+
     // STREAM_MUSIC volume should be changed by the hardware volume controls.
     volumeControlStream = AudioManager.STREAM_MUSIC
     try {

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -80,3 +80,7 @@ THEOplayer_timeUpdateRate = com.theoplayer.TimeUpdateRate.LIMITED_TWO_HZ
 # into fullscreen.
 # See https://github.com/THEOplayer/react-native-theoplayer/blob/develop/doc/fullscreen.md.
 #THEOplayer_reparent_on_fullscreen = true
+
+# Toggle whether to reparent the playerView to the top-most node of the view hierarchy when going
+# into PiP.
+#THEOplayer_reparent_on_PiP = false

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -12,6 +12,7 @@
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-native": "npm:react-native-tvos@^0.76.5-0",
+        "react-native-safe-area-context": "^5.3.0",
         "react-native-status-bar-height": "^2.6.0",
         "react-native-svg": "^15.8.0",
         "react-native-web": "^0.19.13",
@@ -11138,6 +11139,15 @@
       "resolved": "https://registry.npmjs.org/react-native-google-cast/-/react-native-google-cast-4.8.3.tgz",
       "integrity": "sha512-2s/dBr+YYSXYTo7Btx9Az9yOPjnr2GQ8GWU+qDXMsHijrYDafe9uIj7RWFFmx7cL/4RSICx1RwC3vUkHSqaWEA==",
       "peer": true,
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/react-native-safe-area-context": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.3.0.tgz",
+      "integrity": "sha512-glV9bwuozTjf/JDBIBm+ITnukHNaUT3nucgdeADwjtHsfEN3RL5UO6nq99vvdWv5j/O9yCZBvFncM1BBQ+UvpQ==",
       "peerDependencies": {
         "react": "*",
         "react-native": "*"

--- a/example/package.json
+++ b/example/package.json
@@ -19,6 +19,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-native": "npm:react-native-tvos@^0.76.5-0",
+    "react-native-safe-area-context": "^5.3.0",
     "react-native-status-bar-height": "^2.6.0",
     "react-native-svg": "^15.8.0",
     "react-native-web": "^0.19.13",

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -176,7 +176,8 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    marginHorizontal: 2,
+    // on iOS we cannot stretch an inline playerView to cover the whole screen, otherwise it assumes fullscreen presentationMode.
+    marginHorizontal: Platform.select({ ios: 2, default: 0 }),
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -32,9 +32,8 @@ import { MediaCacheMenuButton } from './custom/MediaCacheMenuButton';
 import { MediaCachingTaskListSubMenu } from './custom/MediaCachingTaskListSubMenu';
 import { RenderingTargetSubMenu } from './custom/RenderingTargetSubMenu';
 import { AutoPlaySubMenu } from './custom/AutoPlaySubMenu';
-import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaProvider, SafeAreaView, Edges } from 'react-native-safe-area-context';
 import { usePresentationMode } from './hooks/usePresentationMode';
-import { Edges } from 'react-native-safe-area-context/src/SafeArea.types';
 
 const playerConfig: PlayerConfiguration = {
   // Get your THEOplayer license from https://portal.theoplayer.com/

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -23,9 +23,7 @@ import {
   UiContainer,
 } from '@theoplayer/react-native-ui';
 import { PlayerConfiguration, PlayerEventType, THEOplayer, THEOplayerView, sdkVersions } from 'react-native-theoplayer';
-
-import { Platform, SafeAreaView, StyleSheet, View, ViewStyle } from 'react-native';
-import { getStatusBarHeight } from 'react-native-status-bar-height';
+import { Platform, StatusBar, StyleSheet, View } from 'react-native';
 import { SourceMenuButton, SOURCES } from './custom/SourceMenuButton';
 import { BackgroundAudioSubMenu } from './custom/BackgroundAudioSubMenu';
 import { PiPSubMenu } from './custom/PipSubMenu';
@@ -34,6 +32,8 @@ import { MediaCacheMenuButton } from './custom/MediaCacheMenuButton';
 import { MediaCachingTaskListSubMenu } from './custom/MediaCachingTaskListSubMenu';
 import { RenderingTargetSubMenu } from './custom/RenderingTargetSubMenu';
 import { AutoPlaySubMenu } from './custom/AutoPlaySubMenu';
+import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+import { getStatusBarHeight } from 'react-native-status-bar-height';
 
 const playerConfig: PlayerConfiguration = {
   // Get your THEOplayer license from https://portal.theoplayer.com/
@@ -59,6 +59,7 @@ const playerConfig: PlayerConfiguration = {
   ads: {
     theoads: true,
   },
+  useMedia3: true,
 };
 
 /**
@@ -98,80 +99,87 @@ export default function App() {
     console.log('THEOplayer is ready');
   };
 
-  const needsBorder = Platform.OS === 'ios';
-  const PLAYER_CONTAINER_STYLE: ViewStyle = {
-    position: 'absolute',
-    top: needsBorder ? getStatusBarHeight() : 0,
-    left: needsBorder ? 2 : 0,
-    bottom: 0,
-    right: needsBorder ? 2 : 0,
-    alignItems: 'center',
-    justifyContent: 'center',
-    backgroundColor: '#000000',
-  };
-
   return (
-    <SafeAreaView style={[StyleSheet.absoluteFill, { backgroundColor: '#000000' }]}>
-      <View style={PLAYER_CONTAINER_STYLE}>
-        <THEOplayerView config={playerConfig} onPlayerReady={onPlayerReady}>
-          {player !== undefined && (
-            <UiContainer
-              theme={{ ...DEFAULT_THEOPLAYER_THEME }}
-              player={player}
-              behind={<CenteredDelayedActivityIndicator size={50} />}
-              top={
-                <ControlBar>
-                  <MediaCacheMenuButton>
-                    <MediaCacheDownloadButton />
-                    <MediaCachingTaskListSubMenu />
-                  </MediaCacheMenuButton>
-                  {/*This is a custom menu for source selection.*/}
-                  <SourceMenuButton />
-                  {!Platform.isTV && (
-                    <>
-                      <AirplayButton />
-                      <ChromecastButton />
-                    </>
-                  )}
-                  <LanguageMenuButton />
-                  <SettingsMenuButton>
-                    {/*Note: quality selection is not available on iOS */}
-                    <QualitySubMenu />
-                    <PlaybackRateSubMenu />
-                    <BackgroundAudioSubMenu />
-                    <PiPSubMenu />
-                    <AutoPlaySubMenu />
-                    {Platform.OS === 'android' && <RenderingTargetSubMenu />}
-                  </SettingsMenuButton>
-                </ControlBar>
-              }
-              center={<CenteredControlBar left={<SkipButton skip={-10} />} middle={<PlayButton />} right={<SkipButton skip={30} />} />}
-              bottom={
-                <>
-                  <ControlBar style={{ justifyContent: 'flex-start' }}>
-                    <CastMessage />
-                  </ControlBar>
-                  {
-                    /*Note: RNSlider is not available on tvOS */
-                    !(Platform.isTV && Platform.OS === 'ios') && (
-                      <ControlBar>
-                        <SeekBar />
-                      </ControlBar>
-                    )
-                  }
+    /**
+     * The SafeAreaProvider component is a View from where insets provided by consumers are relative to.
+     * This means that if this view overlaps with any system elements (status bar, notches, etc.) these values will be provided to
+     * descendent consumers such as SafeAreaView.
+     * {@link https://appandflow.github.io/react-native-safe-area-context/api/safe-area-provider}
+     */
+    <SafeAreaProvider>
+      <StatusBar barStyle="light-content" />
+      <SafeAreaView style={{ flex: 1, backgroundColor: 'black' }}>
+        <View style={styles.container}>
+          <THEOplayerView config={playerConfig} onPlayerReady={onPlayerReady}>
+            {player !== undefined && (
+              <UiContainer
+                theme={{ ...DEFAULT_THEOPLAYER_THEME }}
+                player={player}
+                behind={<CenteredDelayedActivityIndicator size={50} />}
+                top={
                   <ControlBar>
-                    <MuteButton />
-                    <TimeLabel showDuration={true} />
-                    <Spacer />
-                    <PipButton />
-                    <FullscreenButton />
+                    <MediaCacheMenuButton>
+                      <MediaCacheDownloadButton />
+                      <MediaCachingTaskListSubMenu />
+                    </MediaCacheMenuButton>
+                    {/*This is a custom menu for source selection.*/}
+                    <SourceMenuButton />
+                    {!Platform.isTV && (
+                      <>
+                        <AirplayButton />
+                        <ChromecastButton />
+                      </>
+                    )}
+                    <LanguageMenuButton />
+                    <SettingsMenuButton>
+                      {/*Note: quality selection is not available on iOS */}
+                      <QualitySubMenu />
+                      <PlaybackRateSubMenu />
+                      <BackgroundAudioSubMenu />
+                      <PiPSubMenu />
+                      <AutoPlaySubMenu />
+                      {Platform.OS === 'android' && <RenderingTargetSubMenu />}
+                    </SettingsMenuButton>
                   </ControlBar>
-                </>
-              }
-            />
-          )}
-        </THEOplayerView>
-      </View>
-    </SafeAreaView>
+                }
+                center={<CenteredControlBar left={<SkipButton skip={-10} />} middle={<PlayButton />} right={<SkipButton skip={30} />} />}
+                bottom={
+                  <>
+                    <ControlBar style={{ justifyContent: 'flex-start' }}>
+                      <CastMessage />
+                    </ControlBar>
+                    {
+                      /*Note: RNSlider is not available on tvOS */
+                      !(Platform.isTV && Platform.OS === 'ios') && (
+                        <ControlBar>
+                          <SeekBar />
+                        </ControlBar>
+                      )
+                    }
+                    <ControlBar>
+                      <MuteButton />
+                      <TimeLabel showDuration={true} />
+                      <Spacer />
+                      <PipButton />
+                      <FullscreenButton />
+                    </ControlBar>
+                  </>
+                }
+              />
+            )}
+          </THEOplayerView>
+        </View>
+      </SafeAreaView>
+    </SafeAreaProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    top: Platform.OS === 'ios' ? getStatusBarHeight() : 0,
+    marginHorizontal: 2,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -33,7 +33,6 @@ import { MediaCachingTaskListSubMenu } from './custom/MediaCachingTaskListSubMen
 import { RenderingTargetSubMenu } from './custom/RenderingTargetSubMenu';
 import { AutoPlaySubMenu } from './custom/AutoPlaySubMenu';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
-import { getStatusBarHeight } from 'react-native-status-bar-height';
 
 const playerConfig: PlayerConfiguration = {
   // Get your THEOplayer license from https://portal.theoplayer.com/
@@ -177,7 +176,6 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    top: Platform.OS === 'ios' ? getStatusBarHeight() : 0,
     marginHorizontal: 2,
     alignItems: 'center',
     justifyContent: 'center',

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   AirplayButton,
   CastMessage,
@@ -22,7 +22,7 @@ import {
   TimeLabel,
   UiContainer,
 } from '@theoplayer/react-native-ui';
-import { PlayerConfiguration, PlayerEventType, THEOplayer, THEOplayerView, sdkVersions } from 'react-native-theoplayer';
+import { PlayerConfiguration, PlayerEventType, PresentationMode, sdkVersions, THEOplayer, THEOplayerView } from 'react-native-theoplayer';
 import { Platform, StatusBar, StyleSheet, View } from 'react-native';
 import { SourceMenuButton, SOURCES } from './custom/SourceMenuButton';
 import { BackgroundAudioSubMenu } from './custom/BackgroundAudioSubMenu';
@@ -33,6 +33,8 @@ import { MediaCachingTaskListSubMenu } from './custom/MediaCachingTaskListSubMen
 import { RenderingTargetSubMenu } from './custom/RenderingTargetSubMenu';
 import { AutoPlaySubMenu } from './custom/AutoPlaySubMenu';
 import { SafeAreaProvider, SafeAreaView } from 'react-native-safe-area-context';
+import { usePresentationMode } from './hooks/usePresentationMode';
+import { Edges } from 'react-native-safe-area-context/src/SafeArea.types';
 
 const playerConfig: PlayerConfiguration = {
   // Get your THEOplayer license from https://portal.theoplayer.com/
@@ -67,6 +69,12 @@ const playerConfig: PlayerConfiguration = {
  */
 export default function App() {
   const [player, setPlayer] = useState<THEOplayer | undefined>(undefined);
+  const presentationMode = usePresentationMode(player);
+
+  // In PiP presentation mode on NewArch Android, there is an issue where SafeAreayView does not update the edges in time,
+  // so explicitly disable them here.
+  const edges: Edges = useMemo(() => (presentationMode === PresentationMode.pip ? [] : ['left', 'top', 'right', 'bottom']), [presentationMode]);
+
   const onPlayerReady = (player: THEOplayer) => {
     setPlayer(player);
     // optional debug logs
@@ -107,7 +115,7 @@ export default function App() {
      */
     <SafeAreaProvider>
       <StatusBar barStyle="light-content" />
-      <SafeAreaView style={{ flex: 1, backgroundColor: 'black' }}>
+      <SafeAreaView edges={edges} style={{ flex: 1, backgroundColor: 'black' }}>
         <View style={styles.container}>
           <THEOplayerView config={playerConfig} onPlayerReady={onPlayerReady}>
             {player !== undefined && (

--- a/example/src/hooks/usePresentationMode.ts
+++ b/example/src/hooks/usePresentationMode.ts
@@ -1,0 +1,16 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import { PlayerEventType, PresentationMode, THEOplayer } from 'react-native-theoplayer';
+
+/**
+ * Returns {@link react-native-theoplayer!THEOplayer.presentationMode | the player's presentationMode}, automatically updating whenever it changes.
+ */
+export const usePresentationMode = (player?: THEOplayer) => {
+  const subscribe = useCallback(
+    (callback: () => void) => {
+      player?.addEventListener(PlayerEventType.PRESENTATIONMODE_CHANGE, callback);
+      return () => player?.removeEventListener(PlayerEventType.PRESENTATIONMODE_CHANGE, callback);
+    },
+    [player],
+  );
+  return useSyncExternalStore(subscribe, () => (player ? player.presentationMode : PresentationMode.inline));
+};

--- a/src/internal/THEOplayerView.tsx
+++ b/src/internal/THEOplayerView.tsx
@@ -343,7 +343,13 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
   };
 
   private _onPresentationModeChange = (event: NativeSyntheticEvent<NativePresentationModeChangeEvent>) => {
-    this.setState({ presentationMode: event.nativeEvent.presentationMode });
+    const presentationMode = event.nativeEvent.presentationMode;
+    this.setState({ presentationMode }, () => {
+      // Re-measure screen size after transitioning to fullscreen.
+      if (presentationMode === PresentationMode.fullscreen) {
+        this.setState({ screenSize: getFullscreenSize() });
+      }
+    });
     this._facade.dispatchEvent(
       new DefaultPresentationModeChangeEvent(
         event.nativeEvent.presentationMode,

--- a/src/internal/utils/Dimensions.ts
+++ b/src/internal/utils/Dimensions.ts
@@ -1,26 +1,18 @@
 import type { ScaledSize } from 'react-native/Libraries/Utilities/Dimensions';
-import { Dimensions, Platform, StatusBar } from 'react-native';
+import { Dimensions, NativeModules, Platform } from 'react-native';
 
 /**
- * Calculate the device's screen dimensions, while taking into account the statusBar height and orientation on Android.
+ * Calculate the device's screen dimensions, while taking into account the full usable screen dimensions on Android.
  */
 export function getFullscreenSize(): ScaledSize {
   const screenSize = Dimensions.get('screen');
 
-  // Adjust for statusBar height on Android, depending on the device's current orientation.
-  if (Platform.OS === 'android' && Platform.Version >= 29) {
-    const statusBarHeight = StatusBar.currentHeight || 0;
-    if (screenSize.width < screenSize.height) {
-      // portrait
-      if (screenSize.height !== Dimensions.get('window').height + statusBarHeight) {
-        screenSize.height = screenSize.height - statusBarHeight;
-      }
-    } else {
-      // landscape
-      if (screenSize.width !== Dimensions.get('window').width) {
-        screenSize.width = screenSize.width - statusBarHeight;
-      }
-    }
+  // For Android, ask the platform for the full usable screen dimensions.
+  // It should return the full usable screen size, including support for edgeToEdge layouts.
+  // {@link https://developer.android.com/develop/ui/views/layout/edge-to-edge}
+  if (Platform.OS === 'android') {
+    const nativeDims: ScaledSize = NativeModules.THEORCTPlayerModule.getUsableScreenDimensions();
+    return nativeDims.width > 0 && nativeDims.height > 0 ? nativeDims : screenSize;
   }
   return screenSize;
 }


### PR DESCRIPTION
The fullscreen behaviour needs some changes on Android

- Recent Android versions include edgeToEdge screen layout; the current screen dimension calculation based om React Native's `Dimension` did not suffice. We now ask the rootView's usable screen dimensions.
- When reparenting, the containerView should always be repositioned to `{top:0, left:0}`, ignoring any translation the React Native lay-out engine (specifically NewArch's Yoga engine) imposes.
- Also works when reparenting is explicitly disabled with the `THEOplayer_reparent_on_fullscreen=false`.
- Checked on API 35,34,33,28 with/wo edge2Edge.  