### PR TITLE
Fix/Android: fix init of player for Old Arch

### DIFF
--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerView.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerView.kt
@@ -50,7 +50,7 @@ class ReactTHEOplayerView(private val reactContext: ThemedReactContext) :
       return
     }
     this.config = config
-    if (!isAttachedToWindow) {
+    if (!isAttachedToWindow && BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       // The view is not attached to the window yet, postpone the initialization.
       return
     }
@@ -76,7 +76,7 @@ class ReactTHEOplayerView(private val reactContext: ThemedReactContext) :
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
-    if (!isInitialized) {
+    if (!isInitialized && BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       config?.let { initialize(it) }
     }
   }


### PR DESCRIPTION
**Summary:**

In some scenarios on Old Arch apps it doesn't init the player so we see just a black screen instead of playback. It happens when we switch to a different screen, then return to the player.

**Test-Plan:**

1. Run the test app
2. After playback is confirmed to work, go to the a different screen like Settings
3. Go back to the player
4. Expected: playback will continue, no black screens