### PR TITLE
Update THEOplayerRCTView+BackgroundAudioConfig.swift

### DIFF
--- a/ios/backgroundAudio/THEOplayerRCTView+BackgroundAudioConfig.swift
+++ b/ios/backgroundAudio/THEOplayerRCTView+BackgroundAudioConfig.swift
@@ -19,7 +19,7 @@ extension THEOplayerRCTView {
     }
 }
 
-struct DefaultBackgroundPlaybackDelegate: BackgroundPlaybackDelegate {
+class DefaultBackgroundPlaybackDelegate: BackgroundPlaybackDelegate {
     func shouldContinueAudioPlaybackInBackground() -> Bool {
         return false
     }


### PR DESCRIPTION
From THEOplayer 8.13.0, `BackgroundPlaybackDelegate` can only be applied on a class.