### PR TITLE
Fix/ Android: Crash on Media3

### DIFF
--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -347,7 +347,7 @@ class ReactTHEOplayerContext private constructor(
             //
             // @remark If the source contains THEOads, media3 is always enabled.
             configAdapter.useMedia3 ||
-              BuildConfig.EXTENSION_THEOADS && source.ads.any { it is TheoAdDescription }
+              (BuildConfig.EXTENSION_THEOADS && source.ads.any { it is TheoAdDescription })
           }
         playerView.player.addIntegration(media3Integration)
       }

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -346,7 +346,8 @@ class ReactTHEOplayerContext private constructor(
             // return false -> the default pipeline will be used to play the selected source.
             //
             // @remark If the source contains THEOads, media3 is always enabled.
-            configAdapter.useMedia3 || source.ads.any { it is TheoAdDescription }
+            configAdapter.useMedia3 ||
+              BuildConfig.EXTENSION_THEOADS && source.ads.any { it is TheoAdDescription }
           }
         playerView.player.addIntegration(media3Integration)
       }


### PR DESCRIPTION
**Summary:**

Fix for Android crash where useMedia3=false and Media3 build flag is enabled.
```
2025-03-14 14:48:32.972 16716-16716 DevLauncher             com.gotv.nflgamecenter.us.lite       E  DevLauncher tries to handle uncaught exception. (Ask Gemini)
java.lang.NoClassDefFoundError: Failed resolution of: Lcom/theoplayer/android/api/ads/theoads/TheoAdDescription;
	at com.theoplayer.ReactTHEOplayerContext.addIntegrations$lambda$11(ReactTHEOplayerContext.kt:389)
	at com.theoplayer.ReactTHEOplayerContext.$r8$lambda$Zwn5VA4SSk_ZRoDs1NImOFEOELM(Unknown Source:0)
	at com.theoplayer.ReactTHEOplayerContext$$ExternalSyntheticLambda7.canPlaySource(D8$$SyntheticClass:0)
	at com.theoplayer.android.internal.media3.J.canPlaySource(SourceFile:26)
```

**Test-plan:**
1. Compile and run a test app with `THEOplayer_extensionMedia3=true` in gradle.properties and useMedia3 = false
2. Watch any VOD
3. Expected: No crash, playback is normal