### PR TITLE
Support for multimedia tunneling on Android with Media3

### DIFF
--- a/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
+++ b/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
@@ -67,8 +67,8 @@ class PlayerConfigAdapter(private val configProps: ReadableMap?) {
         pipConfiguration(PipConfiguration.Builder().build())
         // Opt-out for auto-integrations for now
         autoIntegrations(false)
-        getBoolean(PROP_MULTIMEDIA_TUNNELING_ENABLED)?.let { tunnelingEnabled ->
-          tunnelingEnabled(tunnelingEnabled)
+        if (hasKey(PROP_MULTIMEDIA_TUNNELING_ENABLED)) {
+          tunnelingEnabled(getBoolean(PROP_MULTIMEDIA_TUNNELING_ENABLED))
         }
       }
     }.build()

--- a/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
+++ b/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
@@ -39,6 +39,7 @@ private const val PROP_ALLOWED_MIMETYPES = "allowedMimeTypes"
 private const val PROP_THEOLIVE_CONFIG = "theoLive"
 private const val PROP_THEOLIVE_EXTERNAL_SESSION_ID = "externalSessionId"
 private const val PROP_THEOLIVE_ANALYTICS_DISABLED = "analyticsDisabled"
+private const val PROP_MULTIMEDIA_TUNNELING_ENABLED = "tunnelingEnabled"
 
 class PlayerConfigAdapter(private val configProps: ReadableMap?) {
 
@@ -66,6 +67,9 @@ class PlayerConfigAdapter(private val configProps: ReadableMap?) {
         pipConfiguration(PipConfiguration.Builder().build())
         // Opt-out for auto-integrations for now
         autoIntegrations(false)
+        getBoolean(PROP_MULTIMEDIA_TUNNELING_ENABLED)?.let { tunnelingEnabled ->
+          tunnelingEnabled(tunnelingEnabled)
+        }
       }
     }.build()
   }

--- a/doc/media3.md
+++ b/doc/media3.md
@@ -39,3 +39,19 @@ const playerConfig: PlayerConfiguration = {
   useMedia3: true
 };
 ```
+
+### Multimedia tunneling
+
+The Media3 pipeline provides support for multimedia tunneling, as described in the
+[Android documentation](https://source.android.com/docs/devices/tv/multimedia-tunneling).
+This is disabled by default.
+
+To enable multimedia tunneling, pass the `tunnelingEnabled` flag in the
+[player configuration](../src/api/config/PlayerConfiguration.ts) as shown below:
+
+```tsx
+const playerConfig: PlayerConfiguration = {
+  // ...
+  tunnelingEnabled: true
+};
+```

--- a/src/api/config/PlayerConfiguration.ts
+++ b/src/api/config/PlayerConfiguration.ts
@@ -86,6 +86,22 @@ export interface PlayerConfiguration {
    * The THEOlive configuration for the player.
    */
   theoLive?: TheoLiveConfiguration;
+
+  /**
+   * Whether multimedia tunneling is enabled for the player or not.
+   *
+   * <ul>
+   *     <li>Only supported with the Media3 integration.</li>
+   *     <li>Only supported if the media being played includes both audio and video.</li>
+   *     <li>Only supported on limited number of video codecs and devices.</li>
+   * </ul>
+   *
+   * @defaultValue false
+   *
+   * @remarks
+   * <br/> - This parameter only applies to Android platforms.
+   */
+  tunnelingEnabled?: boolean;
 }
 
 /**


### PR DESCRIPTION
This PR adds logic for configuring the newly added feature of multimedia tunneling on Android with Media3.