### PR TITLE
Feature/parse chapters in ios bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added iOS support for `sseEndpoint` property to `TheoAdDescription`.
+- Added iOS support for sideloaded chapter TextTracks.
 
 ## [9.0.1] - 25-04-08
 

--- a/example/src/custom/sources.json
+++ b/example/src/custom/sources.json
@@ -15,7 +15,7 @@
         "album": "React-Native THEOplayer demos",
         "mediaUri": "https://theoplayer.com",
         "displayIconUri": "https://cdn.theoplayer.com/video/sintel_old/poster.jpg",
-        "artist": "THEOplayer",
+        "artist": "THEOplayer"
       },
       "textTracks": [{
         "kind": "chapters",

--- a/example/src/custom/sources.json
+++ b/example/src/custom/sources.json
@@ -1,5 +1,33 @@
 [
   {
+    "name": "HLS - Sideloaded Chapters",
+    "os": ["ios","android", "web"],
+    "source": {
+      "sources": [
+        {
+          "src": "https://cdn.theoplayer.com/video/sintel/nosubs.m3u8",
+          "type": "application/x-mpegurl",
+        }
+      ],
+      "metadata": {
+        "title": "Sintel",
+        "subtitle": "HLS - Sideloaded Chapters",
+        "album": "React-Native THEOplayer demos",
+        "mediaUri": "https://theoplayer.com",
+        "displayIconUri": "https://cdn.theoplayer.com/video/sintel_old/poster.jpg",
+        "artist": "THEOplayer",
+      },
+      "textTracks": [{
+        "kind": "chapters",
+        "src": "https://cdn.theoplayer.com/video/sintel/chapters.vtt",
+        "format": "webvtt",
+        "srclang": "en",
+        "label": "Chapters",
+        "default": true
+      }]
+    }
+  },
+  {
     "name": "DASH - Thumbnails in manifest",
     "os": ["android", "web"],
     "source": {

--- a/example/src/custom/sources.json
+++ b/example/src/custom/sources.json
@@ -6,7 +6,7 @@
       "sources": [
         {
           "src": "https://cdn.theoplayer.com/video/sintel/nosubs.m3u8",
-          "type": "application/x-mpegurl",
+          "type": "application/x-mpegurl"
         }
       ],
       "metadata": {

--- a/ios/THEOplayerRCTMainEventHandler.swift
+++ b/ios/THEOplayerRCTMainEventHandler.swift
@@ -7,7 +7,7 @@ public class THEOplayerRCTMainEventHandler {
     // MARK: Members
     private weak var player: THEOplayer?
     private weak var presentationModeContext: THEOplayerRCTPresentationModeContext?
-    private var loadedMetadataTracksInfo: [[String:Any]] = []
+    private var loadedMetadataAndChapterTracksInfo: [[String:Any]] = []
         
     // MARK: Events
     var onNativePlay: RCTDirectEventBlock?
@@ -71,8 +71,8 @@ public class THEOplayerRCTMainEventHandler {
         self.attachListeners()
     }
     
-    func setLoadedMetadataTracksInfo(_ metadataTracksInfo: [[String:Any]]) {
-        self.loadedMetadataTracksInfo = metadataTracksInfo
+    func setLoadedMetadataAndChapterTracksInfo(_ tracksInfo: [[String:Any]]) {
+        self.loadedMetadataAndChapterTracksInfo = tracksInfo
     }
     
     // MARK: - attach/dettach main player Listeners
@@ -276,7 +276,7 @@ public class THEOplayerRCTMainEventHandler {
             if let wplayer = player,
                let welf = self,
                let forwardedLoadedMetadataEvent = self?.onNativeLoadedMetadata {
-                let metadata = THEOplayerRCTTrackMetadataAggregator.aggregateTrackMetadata(player: wplayer, metadataTracksInfo: welf.loadedMetadataTracksInfo)
+              let metadata = THEOplayerRCTTrackMetadataAggregator.aggregateTrackMetadata(player: wplayer, metadataTracksInfo: welf.loadedMetadataAndChapterTracksInfo)
                 print(metadata)
                 forwardedLoadedMetadataEvent(metadata)
             }

--- a/ios/THEOplayerRCTPlayerAPI.swift
+++ b/ios/THEOplayerRCTPlayerAPI.swift
@@ -75,11 +75,11 @@ class THEOplayerRCTPlayerAPI: NSObject, RCTBridgeModule {
     func setSource(_ node: NSNumber, src: NSDictionary) -> Void {
         DispatchQueue.main.async {
             if let theView = self.bridge.uiManager.view(forReactTag: node) as? THEOplayerRCTView {
-                let (sourceDescription, metadataTrackDescriptions) = THEOplayerRCTSourceDescriptionBuilder.buildSourceDescription(src)
+                let (sourceDescription, metadataAndChapterTrackDescriptions) = THEOplayerRCTSourceDescriptionBuilder.buildSourceDescription(src)
                 if let player = theView.player {
                     self.triggerViewHierarchyValidation(player)
                     self.setNewSourceDescription(player: player, srcDescription: sourceDescription)
-                    theView.processMetadataTracks(metadataTrackDescriptions: metadataTrackDescriptions)
+                    theView.processMetadataAndChapterTracks(trackDescriptions: metadataAndChapterTrackDescriptions)
                 }
             } else {
                 if DEBUG_PLAYER_API { PrintUtils.printLog(logText: "[NATIVE] Failed to update THEOplayer source.") }

--- a/ios/THEOplayerRCTSourceDescriptionBuilder.swift
+++ b/ios/THEOplayerRCTSourceDescriptionBuilder.swift
@@ -130,14 +130,14 @@ class THEOplayerRCTSourceDescriptionBuilder {
 
         // 3. extract 'textTracks'
         var textTrackDescriptions: [TextTrackDescription]?
-        var metadataTrackDescriptions: [TextTrackDescription]?
+        var metadataAndChapterTrackDescriptions: [TextTrackDescription]?
         if let textTracksDataArray = sourceData[SD_PROP_TEXTTRACKS] as? [[String:Any]] {
             textTrackDescriptions = []
-            metadataTrackDescriptions = []
+          metadataAndChapterTrackDescriptions = []
             for textTracksData in textTracksDataArray {
                 if let textTrackDescription = THEOplayerRCTSourceDescriptionBuilder.buildTextTrackDescriptions(textTracksData) {
-                    if textTrackDescription.kind == .metadata {
-                        metadataTrackDescriptions?.append(textTrackDescription)
+                  if textTrackDescription.kind == .chapters || textTrackDescription.kind == .metadata {
+                      metadataAndChapterTrackDescriptions?.append(textTrackDescription)
                     } else {
                         textTrackDescriptions?.append(textTrackDescription)
                     }
@@ -174,7 +174,7 @@ class THEOplayerRCTSourceDescriptionBuilder {
                                  poster: poster,
                                  metadata: metadataDescription)
         
-        return (sourceDescription, metadataTrackDescriptions)
+        return (sourceDescription, metadataAndChapterTrackDescriptions)
     }
 
     // MARK: Private build methods

--- a/ios/THEOplayerRCTTrackMetadataAggregator.swift
+++ b/ios/THEOplayerRCTTrackMetadataAggregator.swift
@@ -236,14 +236,14 @@ class THEOplayerRCTTrackMetadataAggregator {
         return 0
     }
     
-    class func aggregatedMetadataTrackInfo(metadataTrackDescriptions: [TextTrackDescription], completed: (([[String:Any]]) -> Void)? ) {
+    class func aggregatedMetadataAndChapterTrackInfo(trackDescriptions: [TextTrackDescription], completed: (([[String:Any]]) -> Void)? ) {
         var trackIndex = 0
         var tracksInfo: [[String:Any]] = []
-        for trackDescription in metadataTrackDescriptions {
-            guard trackDescription.kind == .metadata, trackDescription.format == .WebVTT else { continue }
+        for trackDescription in trackDescriptions {
+          guard (trackDescription.kind == .metadata || trackDescription.kind == .chapters), trackDescription.format == .WebVTT else { continue }
             
             let urlString = trackDescription.src.absoluteString
-            THEOplayerRCTSideloadedMetadataProcessor.parseVtt(urlString) { cueArray in
+            THEOplayerRCTSideloadedWebVTTProcessor.parseVtt(urlString) { cueArray in
                 if let cues = cueArray {
                     var track: [String:Any] = [:]
                     let trackUid = 1000 + trackIndex
@@ -269,8 +269,9 @@ class THEOplayerRCTTrackMetadataAggregator {
                         cueIndex += 1
                     }
                     track[PROP_CUES] = cueList
+                  print("cue list length",cueList.count)
                     tracksInfo.append(track)
-                    if tracksInfo.count == metadataTrackDescriptions.count {
+                    if tracksInfo.count == trackDescriptions.count {
                         completed?(tracksInfo)
                     }
                 }

--- a/ios/THEOplayerRCTTrackMetadataAggregator.swift
+++ b/ios/THEOplayerRCTTrackMetadataAggregator.swift
@@ -269,7 +269,6 @@ class THEOplayerRCTTrackMetadataAggregator {
                         cueIndex += 1
                     }
                     track[PROP_CUES] = cueList
-                  print("cue list length",cueList.count)
                     tracksInfo.append(track)
                     if tracksInfo.count == trackDescriptions.count {
                         completed?(tracksInfo)

--- a/ios/THEOplayerRCTView.swift
+++ b/ios/THEOplayerRCTView.swift
@@ -179,10 +179,10 @@ public class THEOplayerRCTView: UIView {
         return self.player
     }
     
-    func processMetadataTracks(metadataTrackDescriptions: [TextTrackDescription]?) {
-        THEOplayerRCTSideloadedMetadataProcessor.loadTrackInfoFromTrackDescriptions(metadataTrackDescriptions) { tracksInfo in
-            self.mainEventHandler.setLoadedMetadataTracksInfo(tracksInfo)
-            self.metadataTrackEventHandler.setLoadedMetadataTracksInfo(tracksInfo)
+    func processMetadataAndChapterTracks(trackDescriptions: [TextTrackDescription]?) {
+      THEOplayerRCTSideloadedWebVTTProcessor.loadTrackInfoFromTrackDescriptions(trackDescriptions) { tracksInfo in
+            self.mainEventHandler.setLoadedMetadataAndChapterTracksInfo(tracksInfo)
+            self.metadataTrackEventHandler.setLoadedMetadataAndChapterTracksInfo(tracksInfo)
         }
     }
     

--- a/ios/sideloadedMetadata/THEOplayerRCTSideloadedMetadataProcessor.swift
+++ b/ios/sideloadedMetadata/THEOplayerRCTSideloadedMetadataProcessor.swift
@@ -9,11 +9,11 @@ struct Cue {
     var cueContent: String
 }
 
-class THEOplayerRCTSideloadedMetadataProcessor {
+class THEOplayerRCTSideloadedWebVTTProcessor {
     
-    class func loadTrackInfoFromTrackDescriptions(_ metadataTrackDescriptions: [TextTrackDescription]?, completed: (([[String:Any]]) -> Void)?) {
-        if let trackDescriptions = metadataTrackDescriptions {
-            THEOplayerRCTTrackMetadataAggregator.aggregatedMetadataTrackInfo(metadataTrackDescriptions: trackDescriptions) { tracksInfo in
+    class func loadTrackInfoFromTrackDescriptions(_ trackDescriptions: [TextTrackDescription]?, completed: (([[String:Any]]) -> Void)?) {
+        if let trackDescriptions = trackDescriptions {
+            THEOplayerRCTTrackMetadataAggregator.aggregatedMetadataAndChapterTrackInfo(trackDescriptions: trackDescriptions) { tracksInfo in
                 completed?(tracksInfo)
             }
         } else {
@@ -34,7 +34,7 @@ class THEOplayerRCTSideloadedMetadataProcessor {
                 }
                 
                 if let vttString = String(data: data, encoding: .utf8) {
-                    let cues = THEOplayerRCTSideloadedMetadataProcessor.parseVTTString(vttString)
+                    let cues = THEOplayerRCTSideloadedWebVTTProcessor.parseVTTString(vttString)
                     completion(cues)
                 } else {
                     completion(nil)
@@ -48,7 +48,7 @@ class THEOplayerRCTSideloadedMetadataProcessor {
             var cues: [Cue] = []
             var currentCue: Cue?
             
-        let separator = THEOplayerRCTSideloadedMetadataProcessor.separatorSequence(vttString)
+        let separator = THEOplayerRCTSideloadedWebVTTProcessor.separatorSequence(vttString)
         let lines = vttString.components(separatedBy: separator)
         for line in lines {
             if line.isEmpty {                                               // process unprocessed cue to list

--- a/ios/sideloadedMetadata/THEOplayerRCTSideloadedMetadataTrackEventHandler.swift
+++ b/ios/sideloadedMetadata/THEOplayerRCTSideloadedMetadataTrackEventHandler.swift
@@ -5,18 +5,18 @@ import THEOplayerSDK
 
 
 class THEOplayerRCTSideloadedMetadataTrackEventHandler {
-    private var loadedMetadataTracksInfo: [[String:Any]] = []
+    private var loadedMetadataAndChapterTracksInfo: [[String:Any]] = []
     // MARK: Events
     var onNativeTextTrackListEvent: RCTDirectEventBlock?
     var onNativeTextTrackEvent: RCTDirectEventBlock?
     
-    func setLoadedMetadataTracksInfo(_ metadataTracksInfo: [[String:Any]]) {
-        self.loadedMetadataTracksInfo = metadataTracksInfo
-        self.triggerAddMetadataTrackEvent(metadataTracksInfo)
+    func setLoadedMetadataAndChapterTracksInfo(_ tracksInfo: [[String:Any]]) {
+        self.loadedMetadataAndChapterTracksInfo = tracksInfo
+        self.triggerAddMetadataOrChapterTrackEvent(tracksInfo)
     }
     
-    func triggerAddMetadataTrackEvent(_ metadataTrackInfo: [[String:Any]]) {
-        for trackInfo in metadataTrackInfo {
+    func triggerAddMetadataOrChapterTrackEvent(_ trackInfo: [[String:Any]]) {
+        for trackInfo in trackInfo {
             if let addTrackEvent = self.onNativeTextTrackListEvent {
                 addTrackEvent([
                     "track" : trackInfo,


### PR DESCRIPTION
This PR adds chapter parsing to the iOS bridge:

- In addition to `.metadata`, also TextTracks of kind `.chapters` are parsed in the iOS bridge
- Function and variable names have been changed to reflect this

This should enable chapter support in the React Native Open Video UI to work on iOS too.