### PR TITLE
Bugfix/android multiple players audio focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue on Android where a muted player would still be paused by the `AudioFocusManager`.
+
 ## [9.1.0] - 25-04-23
 
 ### Added

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -368,6 +368,14 @@ class ReactTHEOplayerContext private constructor(
     audioFocusManager?.abandonAudioFocus()
   }
 
+  private val onVolumeChange = EventListener<VolumeChangeEvent> {
+    if (player.isMuted) {
+      audioFocusManager?.abandonAudioFocus()
+    } else {
+      audioFocusManager?.requestAudioFocus()
+    }
+  }
+
   private fun addListeners() {
     player.apply {
       addEventListener(PlayerEventTypes.SOURCECHANGE, onSourceChange)
@@ -375,6 +383,7 @@ class ReactTHEOplayerContext private constructor(
       addEventListener(PlayerEventTypes.PAUSE, onPause)
       addEventListener(PlayerEventTypes.PLAY, onPlay)
       addEventListener(PlayerEventTypes.ENDED, onEnded)
+      addEventListener(PlayerEventTypes.VOLUMECHANGE, onVolumeChange)
     }
   }
 
@@ -385,6 +394,7 @@ class ReactTHEOplayerContext private constructor(
       removeEventListener(PlayerEventTypes.PAUSE, onPause)
       removeEventListener(PlayerEventTypes.PLAY, onPlay)
       removeEventListener(PlayerEventTypes.ENDED, onEnded)
+      removeEventListener(PlayerEventTypes.VOLUMECHANGE, onVolumeChange)
     }
   }
 

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -354,7 +354,7 @@ class ReactTHEOplayerContext private constructor(
     binder?.updateNotification(PlaybackStateCompat.STATE_PLAYING)
     applyAllowedMediaControls()
     audioBecomingNoisyManager.setEnabled(true)
-    audioFocusManager?.retrieveAudioFocus()
+    audioFocusManager?.requestAudioFocus()
   }
 
   private val onPause = EventListener<PauseEvent> {
@@ -416,7 +416,7 @@ class ReactTHEOplayerContext private constructor(
     mediaSessionConnector?.setActive(BuildConfig.EXTENSION_MEDIASESSION)
     playerView.onResume()
     if (!player.isPaused) {
-      audioFocusManager?.retrieveAudioFocus()
+      audioFocusManager?.requestAudioFocus()
     }
   }
 

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -20,7 +20,6 @@ import com.theoplayer.android.api.ads.dai.GoogleDaiIntegrationFactory
 import com.theoplayer.android.api.ads.ima.GoogleImaConfiguration
 import com.theoplayer.android.api.ads.ima.GoogleImaIntegration
 import com.theoplayer.android.api.ads.ima.GoogleImaIntegrationFactory
-import com.theoplayer.android.api.ads.theoads.TheoAdDescription
 import com.theoplayer.android.api.ads.theoads.TheoAdsIntegration
 import com.theoplayer.android.api.ads.theoads.TheoAdsIntegrationFactory
 import com.theoplayer.android.api.cast.CastIntegration

--- a/android/src/main/java/com/theoplayer/audio/AudioFocusManager.kt
+++ b/android/src/main/java/com/theoplayer/audio/AudioFocusManager.kt
@@ -153,7 +153,7 @@ class AudioFocusManager(
    *
    * @return True if audio focus is granted, false otherwise.
    */
-  fun retrieveAudioFocus(): Boolean {
+  fun requestAudioFocus(): Boolean {
     val result = audioManager?.let {
       AudioManagerCompat.requestAudioFocus(it, audioFocusRequest)
     }

--- a/android/src/main/java/com/theoplayer/audio/AudioFocusManager.kt
+++ b/android/src/main/java/com/theoplayer/audio/AudioFocusManager.kt
@@ -120,6 +120,10 @@ class AudioFocusManager(
     if (player?.ads?.isPlaying == true) {
       return
     }
+    // Don't pause when the player is muted
+    if (player?.isMuted == true) {
+      return
+    }
     synchronized(focusLock) {
       // We should only resume if playback was interrupted
       resumeOnFocusGain = transient && !(player?.isPaused ?: true)
@@ -154,6 +158,10 @@ class AudioFocusManager(
    * @return True if audio focus is granted, false otherwise.
    */
   fun requestAudioFocus(): Boolean {
+    if (player?.isMuted == true) {
+      // There is no point requesting audio focus when the player is muted.
+      return true
+    }
     val result = audioManager?.let {
       AudioManagerCompat.requestAudioFocus(it, audioFocusRequest)
     }


### PR DESCRIPTION
This PR fixes that muted players are paused by the `AudioFocusManager`.