### PR TITLE
Feature/android margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Added
+
+- Added support for the new `TextTrackStyle.marginBottom` and `TextTrackStyle.marginRight` API's on THEOplayer Android SDK v9.5.0.
+
 ### Fixed
 
 - Fixed an issue on iOS where the fullscreen dimensions could become wrong when the device is Flat Up or Flat Down on the table, or in an angle close to these.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -126,8 +126,8 @@ repositories {
   maven { url "https://maven.theoplayer.com/releases" }
 }
 
-// The minimum supported THEOplayer version is 9.0.0
-def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[9.0.0, 10.0.0)')
+// The minimum supported THEOplayer version is 9.5.0
+def theoplayer_sdk_version = safeExtGet('THEOplayer_sdk', '[9.5.0, 10.0.0)')
 def theoplayer_mediasession_version = safeExtGet('THEOplayer_mediasession', '[8.0.0, 10.0.0)')
 def theoplayer_ads_wrapper_version = "9.0.0"
 

--- a/android/src/main/java/com/theoplayer/track/TextTrackStyleAdapter.kt
+++ b/android/src/main/java/com/theoplayer/track/TextTrackStyleAdapter.kt
@@ -12,7 +12,9 @@ private const val PROP_FONT_FAMILY = "fontFamily"
 private const val PROP_FONT_SIZE = "fontSize"
 private const val PROP_WINDOW_COLOR = "windowColor"
 private const val PROP_MARGIN_LEFT = "marginLeft"
+private const val PROP_MARGIN_RIGHT = "marginRight"
 private const val PROP_MARGIN_TOP = "marginTop"
+private const val PROP_MARGIN_BOTTOM = "marginBottom"
 private const val PROP_COLOR_R = "r"
 private const val PROP_COLOR_G = "g"
 private const val PROP_COLOR_B = "b"
@@ -54,8 +56,14 @@ object TextTrackStyleAdapter {
     if (props.hasKey(PROP_MARGIN_TOP)) {
       style.marginTop = props.getInt(PROP_MARGIN_TOP)
     }
+    if (props.hasKey(PROP_MARGIN_BOTTOM)) {
+      style.marginBottom = props.getInt(PROP_MARGIN_BOTTOM)
+    }
     if (props.hasKey(PROP_MARGIN_LEFT)) {
       style.marginLeft = props.getInt(PROP_MARGIN_LEFT)
+    }
+    if (props.hasKey(PROP_MARGIN_RIGHT)) {
+      style.marginRight = props.getInt(PROP_MARGIN_RIGHT)
     }
   }
 

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -4,6 +4,7 @@ buildscript {
   ext {
     buildToolsVersion = "35.0.0"
     // React Native 0.74+ needs minSdkVersion 23+
+    // React Native 0.76+ needs minSdkVersion 24+
     // supportsPictureInPicture and networkSecurityConfig need minSdkVersion 24+
     minSdkVersion = 24
     compileSdkVersion = 35

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -41,7 +41,7 @@ newArchEnabled=true
 hermesEnabled=true
 
 # Version of the THEOplayer SDK, if not specified, the latest available version within bounds is set.
-#THEOplayer_sdk=[9.0.0, 10.0.0)
+#THEOplayer_sdk=[9.5.0, 10.0.0)
 
 # Override Android sdk versions
 #THEOplayer_compileSdkVersion = 34

--- a/src/api/track/TextTrackStyle.ts
+++ b/src/api/track/TextTrackStyle.ts
@@ -60,7 +60,7 @@ export interface TextTrackStyle {
    * <br/> - `'dropshadow'`
    * <br/> - `'raised'`
    * <br/> - `'depressed'`
-   * <br/> - `'uniform`
+   * <br/> - `'uniform'`
    */
   edgeStyle: EdgeStyle | undefined;
 
@@ -85,7 +85,7 @@ export interface TextTrackStyle {
    *
    * @remarks
    * <br/> - The margin is in number of pixels.
-   * <br/> - Available on Web only.
+   * <br/> - Available on Web and Android only.
    */
   marginBottom: number | undefined;
   /**
@@ -101,7 +101,7 @@ export interface TextTrackStyle {
    * @remarks
    * <br/> - The margin is in number of pixels.
    * <br/> - Useful for pushing the subtitles left, so they don't overlap with the UI.
-   * <br/> - Available on Web only.
+   * <br/> - Available on Web and Android only.
    */
   marginRight: number | undefined;
 }


### PR DESCRIPTION
> [!IMPORTANT]
> This should be merged after THEOplayer 9.5.0 is released.

This PR adds support for the new `.marginBottom` and `.marginRight` text track style APIs on the underlying Android SDK.