### PR TITLE
Pass currentTime with seeking & seeked events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed an issue on iOS where the fullscreen dimensions could become wrong when the device is Flat Up or Flat Down on the table, or in an angle close to these.
 
+### Added
+
+- Added `currentTime` property to `SeekingEvent` and `SeekedEvent`, indicating the player time to which is being seeked.
+
 ## [9.2.0] - 25-05-20
 
 ### Added

--- a/ios/THEOplayerRCTMainEventHandler.swift
+++ b/ios/THEOplayerRCTMainEventHandler.swift
@@ -218,7 +218,7 @@ public class THEOplayerRCTMainEventHandler {
         self.seekingListener = player.addEventListener(type: PlayerEventTypes.SEEKING) { [weak self] event in
             if DEBUG_THEOPLAYER_EVENTS { PrintUtils.printLog(logText: "[NATIVE] Received SEEKING event from THEOplayer") }
             if let forwardedSeekingEvent = self?.onNativeSeeking {
-                forwardedSeekingEvent([:])
+                forwardedSeekingEvent(["currentTime": 1e3 * event.currentTime])
             }
         }
         if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] Seeking listener attached to THEOplayer") }
@@ -227,7 +227,7 @@ public class THEOplayerRCTMainEventHandler {
         self.timeUpdateListener = player.addEventListener(type: PlayerEventTypes.SEEKED) { [weak self] event in
             if DEBUG_THEOPLAYER_EVENTS { PrintUtils.printLog(logText: "[NATIVE] Received SEEKED event from THEOplayer") }
             if let forwardedSeekedEvent = self?.onNativeSeeked {
-                forwardedSeekedEvent([:])
+                forwardedSeekedEvent(["currentTime": 1e3 * event.currentTime])
             }
         }
         if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] Seeked listener attached to THEOplayer") }

--- a/src/api/event/PlayerEvent.ts
+++ b/src/api/event/PlayerEvent.ts
@@ -145,3 +145,17 @@ export interface SegmentNotFoundEvent extends Event<PlayerEventType.SEGMENT_NOT_
    */
   readonly retryCount: number;
 }
+
+export interface SeekingEvent extends Event<PlayerEventType.SEEKING> {
+  /**
+   * The player's current time.
+   */
+  readonly currentTime: number;
+}
+
+export interface SeekedEvent extends Event<PlayerEventType.SEEKED> {
+  /**
+   * The player's current time.
+   */
+  readonly currentTime: number;
+}

--- a/src/internal/THEOplayerView.tsx
+++ b/src/internal/THEOplayerView.tsx
@@ -39,6 +39,8 @@ import {
   DefaultVolumeChangeEvent,
   DefaultTimeupdateEvent,
   DefaultResizeEvent,
+  DefaultSeekingEvent,
+  DefaultSeekedEvent,
 } from './adapter/event/PlayerEvents';
 import type { NativeCastEvent } from './adapter/event/native/NativeCastEvent';
 import type {
@@ -61,6 +63,8 @@ import type {
   NativeTimeUpdateEvent,
   NativeVolumeChangeEvent,
   NativeResizeEvent,
+  NativeSeekingEvent,
+  NativeSeekedEvent,
 } from './adapter/event/native/NativePlayerEvent';
 import type { NativeAdEvent } from './adapter/event/native/NativeAdEvent';
 import { THEOplayerAdapter } from './adapter/THEOplayerAdapter';
@@ -86,8 +90,8 @@ interface THEOplayerRCTViewProps {
   onNativePlay: () => void;
   onNativePlaying: () => void;
   onNativePause: () => void;
-  onNativeSeeking: () => void;
-  onNativeSeeked: () => void;
+  onNativeSeeking: (event: NativeSyntheticEvent<NativeSeekingEvent>) => void;
+  onNativeSeeked: (event: NativeSyntheticEvent<NativeSeekedEvent>) => void;
   onNativeEnded: () => void;
   onNativeWaiting: () => void;
   onNativeTimeUpdate: (event: NativeSyntheticEvent<NativeTimeUpdateEvent>) => void;
@@ -236,12 +240,12 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
     this._facade.dispatchEvent(new BaseEvent(PlayerEventType.PAUSE));
   };
 
-  private _onSeeking = () => {
-    this._facade.dispatchEvent(new BaseEvent(PlayerEventType.SEEKING));
+  private _onSeeking = (event: NativeSyntheticEvent<NativeSeekingEvent>) => {
+    this._facade.dispatchEvent(new DefaultSeekingEvent(event.nativeEvent.currentTime));
   };
 
-  private _onSeeked = () => {
-    this._facade.dispatchEvent(new BaseEvent(PlayerEventType.SEEKED));
+  private _onSeeked = (event: NativeSyntheticEvent<NativeSeekedEvent>) => {
+    this._facade.dispatchEvent(new DefaultSeekedEvent(event.nativeEvent.currentTime));
   };
 
   private _onWaiting = () => {

--- a/src/internal/adapter/WebEventForwarder.ts
+++ b/src/internal/adapter/WebEventForwarder.ts
@@ -10,6 +10,8 @@ import type {
   RateChangeEvent as NativeRateChangeEvent,
   ReadyStateChangeEvent as NativeReadyStateChangeEvent,
   RemoveTrackEvent,
+  SeekingEvent as NativeSeekingEvent,
+  SeekedEvent as NativeSeekedEvent,
   TextTrack as NativeTextTrack,
   TextTrackCue as NativeTextTrackCue,
   TimeUpdateEvent as NativeTimeUpdateEvent,
@@ -48,6 +50,8 @@ import {
   DefaultRateChangeEvent,
   DefaultReadyStateChangeEvent,
   DefaultResizeEvent,
+  DefaultSeekedEvent,
+  DefaultSeekingEvent,
   DefaultSegmentNotFoundEvent,
   DefaultTextTrackEvent,
   DefaultTextTrackListEvent,
@@ -211,12 +215,12 @@ export class WebEventForwarder {
     this._facade.dispatchEvent(new BaseEvent(PlayerEventType.PAUSE));
   };
 
-  private readonly onSeeking = () => {
-    this._facade.dispatchEvent(new BaseEvent(PlayerEventType.SEEKING));
+  private readonly onSeeking = (event: NativeSeekingEvent) => {
+    this._facade.dispatchEvent(new DefaultSeekingEvent(event.currentTime * 1e3));
   };
 
-  private readonly onSeeked = () => {
-    this._facade.dispatchEvent(new BaseEvent(PlayerEventType.SEEKED));
+  private readonly onSeeked = (event: NativeSeekedEvent) => {
+    this._facade.dispatchEvent(new DefaultSeekedEvent(event.currentTime * 1e3));
   };
 
   private readonly onEnded = () => {

--- a/src/internal/adapter/event/PlayerEvents.ts
+++ b/src/internal/adapter/event/PlayerEvents.ts
@@ -12,6 +12,7 @@ import {
   ChromecastErrorEvent,
   DurationChangeEvent,
   ErrorEvent,
+  Interstitial,
   LoadedMetadataEvent,
   MediaTrack,
   MediaTrackEvent,
@@ -28,19 +29,21 @@ import {
   RateChangeEvent,
   ReadyStateChangeEvent,
   ResizeEvent,
+  SeekedEvent,
+  SeekingEvent,
   SegmentNotFoundEvent,
   TextTrack,
   TextTrackCue,
   TextTrackEvent,
   TextTrackEventType,
   TextTrackListEvent,
+  TheoAdsEvent,
+  TheoAdsEventType,
   TimeRange,
   TimeUpdateEvent,
   TrackListEventType,
   VolumeChangeEvent,
 } from 'react-native-theoplayer';
-import { TheoAdsEvent, TheoAdsEventType } from '../../../api/event/TheoAdsEvent';
-import { Interstitial } from '../../../api/theoads/interstitial/Interstitial';
 
 export class DefaultLoadedMetadataEvent extends BaseEvent<PlayerEventType.LOADED_METADATA> implements LoadedMetadataEvent {
   constructor(
@@ -133,6 +136,18 @@ export class DefaultSegmentNotFoundEvent extends BaseEvent<PlayerEventType.SEGME
     public retryCount: number,
   ) {
     super(PlayerEventType.SEGMENT_NOT_FOUND);
+  }
+}
+
+export class DefaultSeekingEvent extends BaseEvent<PlayerEventType.SEEKING> implements SeekingEvent {
+  constructor(public readonly currentTime: number) {
+    super(PlayerEventType.SEEKING);
+  }
+}
+
+export class DefaultSeekedEvent extends BaseEvent<PlayerEventType.SEEKED> implements SeekedEvent {
+  constructor(public readonly currentTime: number) {
+    super(PlayerEventType.SEEKED);
   }
 }
 

--- a/src/internal/adapter/event/native/NativePlayerEvent.ts
+++ b/src/internal/adapter/event/native/NativePlayerEvent.ts
@@ -68,6 +68,20 @@ export interface NativeReadyStateChangeEvent {
   readonly readyState: number;
 }
 
+export interface NativeSeekingEvent {
+  /**
+   * The player's currentTime.
+   */
+  readonly currentTime: number;
+}
+
+export interface NativeSeekedEvent {
+  /**
+   * The player's currentTime.
+   */
+  readonly currentTime: number;
+}
+
 export interface NativePresentationModeChangeEvent {
   /**
    * The player's new presentation mode.


### PR DESCRIPTION
Added `currentTime` property to seeked & seeking events, in line with native SDKs. 