### PR TITLE
Prevent PiP crash during IMA ad on Android 8-11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fixed an issue on iOS where the fullscreen dimensions could become wrong when the device is Flat Up or Flat Down on the table, or in an angle close to these.
+- Fixed an issue on Android where switching to the PiP window during an IMA ad caused a crash on Android 8-11.
 
 ## [9.2.0] - 25-05-20
 

--- a/android/src/main/java/com/theoplayer/presentation/PipUtils.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PipUtils.kt
@@ -252,7 +252,7 @@ class PipUtils(
     val intent = Intent(ACTION_MEDIA_CONTROL).putExtra(EXTRA_ACTION, requestCode)
     val pendingIntent =
       PendingIntent.getBroadcast(reactContext, requestCode, intent, PendingIntent.FLAG_IMMUTABLE)
-    val icon: Icon = Icon.createWithResource(reactContext, if (enabled) iconId else NO_ICON)
+    val icon: Icon = Icon.createWithResource(reactContext, if (enabled) iconId else if (Build.VERSION.SDK_INT in Build.VERSION_CODES.O..Build.VERSION_CODES.R) android.R.drawable.screen_background_light_transparent else NO_ICON)
     val title = reactContext.getString(titleId)
     val desc = reactContext.getString(descId)
     return RemoteAction(icon, title, desc, pendingIntent)

--- a/android/src/main/java/com/theoplayer/presentation/PipUtils.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PipUtils.kt
@@ -252,7 +252,17 @@ class PipUtils(
     val intent = Intent(ACTION_MEDIA_CONTROL).putExtra(EXTRA_ACTION, requestCode)
     val pendingIntent =
       PendingIntent.getBroadcast(reactContext, requestCode, intent, PendingIntent.FLAG_IMMUTABLE)
-    val icon: Icon = Icon.createWithResource(reactContext, if (enabled) iconId else if (Build.VERSION.SDK_INT in Build.VERSION_CODES.O..Build.VERSION_CODES.R) android.R.drawable.screen_background_light_transparent else NO_ICON)
+    val icon: Icon = Icon.createWithResource(
+      reactContext,
+      when {
+        enabled -> iconId
+        // On Android 8-11 devices, if you go to PiP during an IMA ad on Android,
+        // the NO_ICON causes a System UI crash.
+        Build.VERSION.SDK_INT in Build.VERSION_CODES.O..Build.VERSION_CODES.R ->
+          android.R.drawable.screen_background_light_transparent
+        else -> NO_ICON
+      }
+    )
     val title = reactContext.getString(titleId)
     val desc = reactContext.getString(descId)
     return RemoteAction(icon, title, desc, pendingIntent)


### PR DESCRIPTION
This PR aims to work around a crash that happens only on Android 8-11 devices if you go to PiP during an IMA ad on Android. The `NO_ICON` [here](https://github.com/THEOplayer/react-native-theoplayer/blob/develop/android/src/main/java/com/theoplayer/presentation/PipUtils.kt#L255) causes a System UI crash when transitioning to PiP:

```
FATAL EXCEPTION: main
Process: com.android.systemui, PID: 13320
java.lang.NullPointerException: Attempt to invoke virtual method 'void android.graphics.drawable.Drawable.setTint(int)' on a null object reference
	at com.android.systemui.pip.phone.PipMenuActivity.lambda$updateActionViews$4(PipMenuActivity.java:565)
	at com.android.systemui.pip.phone.-$$Lambda$PipMenuActivity$FgVNA6rqcnXmAeLQlbztL7Zw7mU.onDrawableLoaded(Unknown Source:2)
	at android.graphics.drawable.Icon$LoadDrawableTask$1.run(Icon.java:986)
	at android.os.Handler.handleCallback(Handler.java:938)
	at android.os.Handler.dispatchMessage(Handler.java:99)
	at android.os.Looper.loop(Looper.java:223)
	at android.app.ActivityThread.main(ActivityThread.java:7656)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:947)
``` 

This change provides a fully transparent "placeholder" icon to prevent the crash on the affected Android versions.

Tests before any changes (all tested on emulators):
- Android 8.0: :x:
- Android 8.1: :x:
- Android 9: :x:
- Android 10: :x:
- Android 11: :x:
- Android 12: :white_check_mark:
- Android 13: :white_check_mark:
- Android 14: :white_check_mark:
- Android 15: :white_check_mark:

Retesting after the workaround:
- Android 8.0: :white_check_mark:
- Android 8.1: :white_check_mark:
- Android 9: :white_check_mark:
- Android 10: :white_check_mark:
- Android 11: :white_check_mark:
- Android 12: :white_check_mark:
- Android 13: :white_check_mark:
- Android 14: :white_check_mark:
- Android 15: :white_check_mark:

Internal ticket: THEOSD-15580