### PR TITLE
Feat/ Android: add config to control pip reparenting

### DIFF
--- a/android/src/main/java/com/theoplayer/presentation/PipConfig.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PipConfig.kt
@@ -2,6 +2,13 @@ package com.theoplayer.presentation
 
 data class PipConfig(
   /**
+   * Whether Picture in Picture should reparent player to the root.
+   *
+   * @defaultValue `false`
+   */
+  val reparentPip: Boolean? = false,
+
+  /**
    * Set whether the app should transition to PiP automatically when going to the background.
    *
    * @defaultValue `false`

--- a/android/src/main/java/com/theoplayer/presentation/PipConfigAdapter.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PipConfigAdapter.kt
@@ -5,10 +5,16 @@ import com.facebook.react.bridge.ReadableMap
 object PipConfigAdapter {
 
   private const val PROP_AUTO = "startsAutomatically"
+  private const val PROP_REPARENT = "reparentPip"
 
   fun fromProps(configProps: ReadableMap?): PipConfig {
     return PipConfig(
-      if (configProps?.hasKey(PROP_AUTO) == true) configProps.getBoolean(PROP_AUTO) else false
+      reparentPip = if (configProps?.hasKey(PROP_REPARENT) == true)
+        configProps.getBoolean(PROP_REPARENT)
+      else false,
+      startsAutomatically = if (configProps?.hasKey(PROP_AUTO) == true)
+        configProps.getBoolean(PROP_AUTO)
+      else false
     )
   }
 }

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -149,7 +149,7 @@ class PresentationManager(
     try {
       pipUtils.enable()
       reactContext.currentActivity?.enterPictureInPictureMode(pipUtils.getPipParams())
-      if (BuildConfig.REPARENT_ON_PIP) {
+      if (BuildConfig.REPARENT_ON_PIP && pipConfig.reparentPip == true) {
         reparentPlayerToRoot()
       }
     } catch (_: Exception) {

--- a/src/api/pip/PiPConfiguration.ts
+++ b/src/api/pip/PiPConfiguration.ts
@@ -12,6 +12,14 @@ export interface PiPConfiguration {
   readonly startsAutomatically?: boolean;
 
   /**
+   * Whether Picture in Picture should reparent player to the root.
+   *
+   * @defaultValue `true`
+   * @remark: Only configurable for Android.
+   */
+  readonly reparentPip?: boolean;
+
+  /**
    * Whether Picture in Picture should remain active when setting a new (non-undefined) source.
    *
    * @defaultValue `false`


### PR DESCRIPTION
It turned out that we should be able to switch off PiP reparenting on Android dynamically.

**Test steps:**
1. Run the test Android app with the flag REPARENT_PIP enabled
2. Watch any VOD
3. Move to BG to activate PiP
4. Expected: it shouldn't reparent the player to root on Android PiP by default