### PR TITLE
Feature/docs platform tag

### DIFF
--- a/src/api/THEOplayerView.ts
+++ b/src/api/THEOplayerView.ts
@@ -19,8 +19,7 @@ export interface THEOplayerViewProps {
    *
    * @defaultValue A style that enforces aspectRatio 16:9.
    *
-   * @remarks
-   * <br/> - This property only applies to iOS & Android platforms.
+   * @platform ios,android
    */
   posterStyle?: StyleProp<ImageStyle> | undefined;
 

--- a/src/api/abr/ABRConfiguration.ts
+++ b/src/api/abr/ABRConfiguration.ts
@@ -64,20 +64,20 @@ export interface ABRConfiguration {
    * The adaptive bitrate strategy.
    *
    * @defaultValue `'bandwidth'`
-   * @remarks
-   * <br/> - This property is currently supported on Web and Android platforms only.
+   *
+   * @platform web,android
    */
   strategy?: ABRStrategy;
 
   /**
    * The amount which the player should buffer ahead of the current playback position, in seconds.
    *
+   * @defaultValue `20`
+   *
    * @remarks
    * <br/> - Before v4.3.0: This duration has a maximum of 60 seconds.
    * <br/> - After v4.3.0: This duration has no maximum.
    * <br/> - The player might reduce or ignore the configured amount because of device or performance constraints.
-   *
-   * @defaultValue `20`
    */
   targetBuffer?: number;
 
@@ -91,8 +91,7 @@ export interface ABRConfiguration {
    *
    * @defaultValue `30`
    *
-   * @remarks
-   * <br/> - This property is currently supported on Web platforms only.
+   * @platform web
    */
   bufferLookbackWindow?: number;
 
@@ -104,8 +103,7 @@ export interface ABRConfiguration {
    * it will reduce `maxBufferLength` and restrict `targetBuffer` to be less than
    * this maximum.
    *
-   * @remarks
-   * <br/> - This property is currently supported on Web platforms only.
+   * @platform web
    */
   readonly maxBufferLength?: number;
 
@@ -115,8 +113,7 @@ export interface ABRConfiguration {
    * Set preferredPeakBitRate to non-zero to indicate that the player should attempt to limit item playback to that bit rate, expressed in bits per second.
    * If network bandwidth consumption cannot be lowered to meet the preferredPeakBitRate, it will be reduced as much as possible while continuing to play the item.
    *
-   * @remarks
-   * <br/> - This property is supported on iOS platforms only.
+   * @platform ios
    */
   preferredPeakBitRate?: number;
 
@@ -126,8 +123,7 @@ export interface ABRConfiguration {
    * The default value is (0,0), which indicates that the client enforces no limit on video resolution. Other values indicate a preferred maximum video resolution.
    * It only applies to HTTP Live Streaming asset.
    *
-   * @remarks
-   * <br/> - This property is supported on iOS platforms only.
+   * @platform ios
    */
   preferredMaximumResolution?: Resolution;
 }

--- a/src/api/ads/AdsConfiguration.ts
+++ b/src/api/ads/AdsConfiguration.ts
@@ -48,8 +48,7 @@ export interface AdsConfiguration {
   /**
    * The Google IMA configuration.
    *
-   * @remarks
-   * <br/> - This is only available to define IMA Settings on iOS and/or Android.
+   * @platform ios,android
    */
   ima?: GoogleImaConfiguration;
 
@@ -59,11 +58,12 @@ export interface AdsConfiguration {
    * @since React Native THEOplayer SDK v8.4.0.
    * @since Native THEOplayer SDK v8.2.0.
    *
+   * @defaultValue `false`
+   *
+   * @platform web
+   *
    * @remarks
    * <br/> - This must be set to `true` in order to schedule a {@link TheoAdDescription}.
-   * <br/> - This only applies to Web platforms.
-   *
-   * @defaultValue `false`
    */
   theoads?: boolean;
 }

--- a/src/api/ads/GoogleImaAd.ts
+++ b/src/api/ads/GoogleImaAd.ts
@@ -87,9 +87,10 @@ export interface GoogleImaAd extends Ad {
   /**
    * The description of the ad from the VAST response.
    *
+   * @platform web,android
+   *
    * @remarks
    * <br/> - Available for `google-ima` and `google-dai` integrations only.
-   * <br/> - Available on Web and Android.
    */
   description: string | undefined;
 }

--- a/src/api/ads/GoogleImaAd.ts
+++ b/src/api/ads/GoogleImaAd.ts
@@ -1,9 +1,6 @@
 /**
  * Represents a Google IMA creative compliant to the VAST specification.
  *
- * @remarks
- * <br/> - Available since v2.60.0.
- *
  * @public
  */
 import type { Ad } from './Ad';

--- a/src/api/ads/GoogleImaConfiguration.ts
+++ b/src/api/ads/GoogleImaConfiguration.ts
@@ -15,6 +15,7 @@ export interface GoogleImaConfiguration {
    * latency and thus user experience. This applies to all VAST wrapper ads. If
    * the number of redirects exceeds |maxRedirects|, the ad request will fail with
    * error code 302.
+   *
    * @defaultValue `4`
    */
   maxRedirects?: number;
@@ -25,7 +26,8 @@ export interface GoogleImaConfiguration {
   featureFlags?: { [flag: string]: string };
 
   /**
-   * Specifies whether to automatically play VMAP and ad rules ad breaks. The
+   * Specifies whether to automatically play VMAP and ad rules ad breaks.
+   *
    * @defaultValue `true`
    */
   autoPlayAdBreaks?: boolean;
@@ -40,6 +42,7 @@ export interface GoogleImaConfiguration {
    * Toggles debug mode which will output detailed log information to the console.
    * Debug mode should be disabled in Release and will display a watermark when
    * enabled.
+   *
    * @defaultValue `false`
    */
   enableDebugMode?: boolean;
@@ -54,8 +57,8 @@ export interface GoogleImaConfiguration {
   bitrate?: number;
 
   /**
-   * The amount of time that the SDK will wait before moving onto the next ad for loading. 
-   * This value will be specified in seconds. 
+   * The amount of time that the SDK will wait before moving onto the next ad for loading.
+   * This value will be specified in seconds.
    */
   adLoadTimeout?: number;
 }

--- a/src/api/ads/Omid.ts
+++ b/src/api/ads/Omid.ts
@@ -48,6 +48,7 @@ export interface Omid {
 
   /**
    * Adds an {@link OmidFriendlyObstruction}.
+   *
    * @param obstruction
    */
   addFriendlyObstruction(obstruction: OmidFriendlyObstruction): void;

--- a/src/api/backgroundAudio/BackgroundAudioConfiguration.ts
+++ b/src/api/backgroundAudio/BackgroundAudioConfiguration.ts
@@ -15,7 +15,8 @@ export interface BackgroundAudioConfiguration {
    * Whether background audio should be resumed after an interruption on iOS (e.g. incoming call).
    *
    * @defaultValue `false`
-   * @remarks Applies to iOS only, impacting behaviour for handling interruptions.
+   *
+   * @platform ios
    */
   readonly shouldResumeAfterInterruption?: boolean;
 
@@ -23,7 +24,8 @@ export interface BackgroundAudioConfiguration {
    * Specify the mode for the native iOS AVAudioSession.
    *
    * @defaultValue `AudioSessionMode.MOVIE_PLAYBACK`
-   * @remarks Applies to iOS only, impacting behaviour for handling interruptions.
+   *
+   * @platform ios
    */
   readonly audioSessionMode?: AudioSessionMode;
 }

--- a/src/api/cache/CachingTask.ts
+++ b/src/api/cache/CachingTask.ts
@@ -71,8 +71,9 @@ export interface CachingTask extends EventDispatcher<CachingTaskEventMap> {
   /**
    * The estimation of the amount this task will download and store, in bytes.
    *
+   * @platform web,android
+   *
    * @remarks
-   * <br/> - Available only on Web and Android.
    * <br/> - Returns -1 if the estimate is not available yet.
    */
   readonly bytes: number;

--- a/src/api/cache/CachingTaskParameters.ts
+++ b/src/api/cache/CachingTaskParameters.ts
@@ -3,8 +3,7 @@ import type { CachingPreferredTrackSelection } from "./CachingPreferredTrackSele
 /**
  * The types of cache storage supported by THEOplayer.
  *
- * @remarks
- * <br/> - Available only on Android.
+ * @platform android
  */
 export enum StorageType {
   /**
@@ -36,13 +35,14 @@ export interface CachingTaskParameters {
   /**
    * The amount of data to cache for the given stream.
    *
+   * @platform web,android
+   *
    * @remarks
-   * <br/> - Available only on Web and Android. On iOS this value we always be '100%'.
+   * <br/> - On iOS this value will always be '100%'.
    *
    * Possible formats:
    * <br/> - A number in seconds.
    * <br/> - A percentage string (XX%) for a proportion of the content duration.
-   *
    */
   readonly amount: number | string;
 
@@ -71,8 +71,9 @@ export interface CachingTaskParameters {
   /**
    * The preferred audio/text tracks to cache.
    *
+   * @platform ios,android
+   *
    * @remarks
-   * <br/> - Available only on iOS and Android.
    * <br/> - By default, the first track will be picked.
    */
   readonly preferredTrackSelection?: CachingPreferredTrackSelection;
@@ -80,8 +81,9 @@ export interface CachingTaskParameters {
   /**
    * An indication of whether the data should be cached on a cellular network, or only on WIFI. Defaults to true.
    *
+   * @platform ios
+   *
    * @remarks
-   * <br/> - Available only on iOS.
    * <br/> - The value can not be changed on a scheduled asset.
    * <br/> - If the download is scheduled/started on WIFI-only mode, and suddenly we would like allow Cellular Network download too, the `CachingTask` has to be removed and scheduled again with the new `CachingParamaters`.
    */
@@ -90,10 +92,9 @@ export interface CachingTaskParameters {
   /**
    * The storage type to use for caching.
    *
-   * @remarks
-   * <br/> - Available only on Android.
-   *
    * @defaultValue [StorageType.MEDIA3]
+   *
+   * @platform android
    */
   readonly storageType?: StorageType;
 }

--- a/src/api/config/PlayerConfiguration.ts
+++ b/src/api/config/PlayerConfiguration.ts
@@ -66,8 +66,7 @@ export interface PlayerConfiguration {
   /**
    * The retry configuration for the player.
    *
-   * @remarks
-   * <br/> - This parameter only applies to Web and Android platforms.
+   * @platform web,android
    */
   readonly retryConfiguration?: RetryConfiguration;
 
@@ -77,8 +76,7 @@ export interface PlayerConfiguration {
    *
    * @defaultValue Three times the target duration of a segment, as specified by the manifest.
    *
-   * @remarks
-   * <br/> - This parameter only applies to Web and Android platforms.
+   * @platform web,android
    */
   liveOffset?: number;
 
@@ -90,22 +88,22 @@ export interface PlayerConfiguration {
   /**
    * Whether multimedia tunneling is enabled for the player or not.
    *
-   * <ul>
-   *     <li>Only supported with the Media3 integration.</li>
-   *     <li>Only supported if the media being played includes both audio and video.</li>
-   *     <li>Only supported on limited number of video codecs and devices.</li>
-   * </ul>
-   *
    * @defaultValue false
    *
+   * @platform android
+   *
    * @remarks
-   * <br/> - This parameter only applies to Android platforms.
+   * <br/> - Only supported with the Media3 integration.
+   * <br/> - Only supported if the media being played includes both audio and video.
+   * <br/> - Only supported on limited number of video codecs and devices.
    */
   tunnelingEnabled?: boolean;
 }
 
 /**
  * The muted autoplay policy of a player for web.
+ *
+ * @remarks
  * <br/> - `'none'`: Disallow muted autoplay. If the player is requested to autoplay while unmuted, and the platform does not support unmuted autoplay, the player will not start playback.
  * <br/> - `'all'`: Allow muted autoplay. If the player is requested to autoplay while unmuted, and the platform supports muted autoplay, the player will start muted playback.
  * <br/> - `'content'`: Allow muted autoplay only for the main content. Disallow muted autoplay for e.g. advertisements. (Not yet supported.)

--- a/src/api/event/AdEvent.ts
+++ b/src/api/event/AdEvent.ts
@@ -112,16 +112,14 @@ export enum AdEventType {
   /**
    * Dispatched when an ad is clicked.
    *
-   * @remarks
-   * <br/> - Available only on iOS and Android.
+   * @platform ios,android
    */
   AD_CLICKED = 'adclicked',
 
   /**
    * Dispatched when a non-clickthrough portion of an ad is tapped.
    *
-   * @remarks
-   * <br/> - Available only on iOS and Android.
+   * @platform ios,android
    */
   AD_TAPPED = 'adtapped',
 
@@ -131,8 +129,7 @@ export enum AdEventType {
    * - On iOS and Android mobile apps, the SDK will navigate to the landing page.
    * - On tvOS and Android TV, the SDK will present a modal dialog containing the VAST icon fallback image.
    *
-   * @remarks
-   * <br/> - Available only on Android.
+   * @platform android
    *
    * @see <a href="https://developers.google.com/interactive-media-ads/docs/sdks/android/client-side/api/reference/com/google/ads/interactivemedia/v3/api/AdEvent.AdEventType#public-static-final-adevent.adeventtype-icon_tapped">Android IMA reference</a>
    */
@@ -141,8 +138,7 @@ export enum AdEventType {
   /**
    * Dispatched when the user has closed the icon fallback image dialog.
    *
-   * @remarks
-   * <br/> - Available only on Android.
+   * @platform android
    *
    * @see <a href="https://developers.google.com/interactive-media-ads/docs/sdks/android/client-side/api/reference/com/google/ads/interactivemedia/v3/api/AdEvent.AdEventType#public-static-final-adevent.adeventtype-icon_fallback_image_closed">Android IMA reference</a>
    */

--- a/src/api/event/PlayerEvent.ts
+++ b/src/api/event/PlayerEvent.ts
@@ -61,8 +61,7 @@ export enum PresentationModeChangePipContext {
   /**
    * The app is transitioning to the PiP frame.
    *
-   * @remarks
-   * <br/> - This property only applies to Android platforms.
+   * @platform android
    */
   TRANSITIONING_TO_PIP = 'transitioning-to-pip',
 }

--- a/src/api/media/MediaControlConfiguration.ts
+++ b/src/api/media/MediaControlConfiguration.ts
@@ -19,8 +19,7 @@ export interface MediaControlConfiguration {
    *
    * @defaultValue `true`
    *
-   * @remarks
-   * <br/> - This property only applies to Web and Android.
+   * @platform web,android
    */
   readonly mediaSessionEnabled?: boolean;
 
@@ -44,8 +43,7 @@ export interface MediaControlConfiguration {
    *
    * @defaultValue `false`
    *
-   * @remarks
-   * <br/> - This property only applies to iOS and Android.
+   * @platform ios,android
    */
   readonly convertSkipToSeek?: boolean;
 }

--- a/src/api/millicast/MillicastConnectOptions.ts
+++ b/src/api/millicast/MillicastConnectOptions.ts
@@ -76,6 +76,7 @@ export interface MillicastConnectOptions {
    * Override which events will be delivered by the server.
    *
    * @platform web
+   *
    * @remarks
    * Possible values are: `'active'`,`'inactive'`,`'vad'`,`'layers'`,`'viewercount'` and `'updated'`
    */
@@ -85,6 +86,7 @@ export interface MillicastConnectOptions {
    * Do not receive media from these source ids.
    *
    * @platform web,android,ios
+   *
    * @remarks
    * Maps to the property `excludedSourceId` on iOS and Android.
    */
@@ -116,10 +118,11 @@ export interface MillicastConnectOptions {
    * Select the simulcast encoding layer and svc layers for the main video track, leave empty for automatic layer selection based on bandwidth estimation.
    *
    * @platform web
+   *
    * @remarks
    * See [LayerInfo](https://millicast.github.io/millicast-sdk/global.html#LayerInfo) for more details
    */
-  layer?: MillicastLayerInfo
+  layer?: MillicastLayerInfo;
 
   /**
    * Sets the maximum bitrate in KBps that the subscriber can receive.
@@ -140,6 +143,7 @@ export interface MillicastConnectOptions {
    * Number of audio tracks to receive VAD multiplexed audio for secondary sources.
    *
    * @platform web,android,ios
+   *
    * @remarks
    * Maps to the property `multiplexedAudioTrack` on iOS and Android.
    */

--- a/src/api/pip/PiPConfiguration.ts
+++ b/src/api/pip/PiPConfiguration.ts
@@ -15,7 +15,8 @@ export interface PiPConfiguration {
    * Whether Picture in Picture should reparent player to the root.
    *
    * @defaultValue `false`
-   * @remark: Only configurable for Android.
+   *
+   * @platform android
    */
   readonly reparentPip?: boolean;
 
@@ -23,7 +24,8 @@ export interface PiPConfiguration {
    * Whether Picture in Picture should remain active when setting a new (non-undefined) source.
    *
    * @defaultValue `false`
-   * @remark: Only configurable for iOS.
+   *
+   * @platform ios
    */
   readonly retainPipOnSourceChange?: boolean;
 }

--- a/src/api/playback/PlaybackSettingsAPI.ts
+++ b/src/api/playback/PlaybackSettingsAPI.ts
@@ -12,11 +12,10 @@ export interface PlaybackSettingsAPI {
    * </ul>
    *
    * @experimental
+   *
    * @param {boolean} useFastStartup Whether fast startup is enabled.
    *
-   * @remarks
-   * - This API is experimental.
-   * - This property is supported on Android platforms only.
+   * @platform android
    */
   useFastStartup(useFastStartup: boolean): void;
 
@@ -31,9 +30,7 @@ export interface PlaybackSettingsAPI {
    * @param {number} correctionMs The correction delay in milliseconds.
    *                              Positive values advance the audio, while negative values delay it.
    *
-   * @remarks
-   * - This API is experimental.
-   * - This property is supported on Android platforms only.
+   * @platform android
    */
   setLipSyncCorrection(correctionMs: number): void;
 }

--- a/src/api/player/THEOplayer.ts
+++ b/src/api/player/THEOplayer.ts
@@ -157,9 +157,6 @@ export interface THEOplayer extends EventDispatcher<PlayerEventMap> {
 
   /**
    * The text track style API.
-   *
-   * @remarks
-   * Only available for Web.
    */
   readonly textTrackStyle: TextTrackStyle;
 
@@ -186,8 +183,7 @@ export interface THEOplayer extends EventDispatcher<PlayerEventMap> {
   /**
    * Used to set the aspect ratio of the player.
    *
-   * @remarks
-   * Only available for iOS and Android.
+   * @platform ios,android
    */
   aspectRatio: AspectRatio;
 
@@ -195,8 +191,8 @@ export interface THEOplayer extends EventDispatcher<PlayerEventMap> {
    * Specifies where the player is displaying the video.
    *
    * @defaultValue `SURFACE_VIEW`
-   * @remarks
-   * Only available for Android.
+   *
+   * @platform android
    */
   renderingTarget?: RenderingTarget;
 
@@ -204,8 +200,8 @@ export interface THEOplayer extends EventDispatcher<PlayerEventMap> {
    * Toggle the wake-lock on the player view. The screen will time out if disabled.
    *
    * @defaultValue `true`
-   * @remarks
-   * Only available on Android.
+   *
+   * @platform android
    */
   keepScreenOn: boolean;
 

--- a/src/api/source/SourceDescription.ts
+++ b/src/api/source/SourceDescription.ts
@@ -350,7 +350,8 @@ export interface BaseSource {
    * The playback pipeline to use for this stream.
    *
    * @defaultValue [PlaybackPipeline.MEDIA3]
-   * @since v9.0.0
+   * @since React Native THEOplayer SDK v9.0.0.
+   * @since Native THEOplayer SDK v9.0.0.
    * @platform android
    */
   playbackPipeline?: PlaybackPipeline;
@@ -389,8 +390,7 @@ export interface TypedSource extends BaseSource {
    *
    * @platform ios,android
    *
-   * @remarks
-   * <br/> - Available since v7.9.0.
+   * @since React Native THEOplayer SDK v7.9.0.
    */
   headers?: { [key: string]: string };
 

--- a/src/api/source/SourceDescription.ts
+++ b/src/api/source/SourceDescription.ts
@@ -314,7 +314,6 @@ export interface BaseSource {
    * The URL of a time server used by the player to synchronise the time in DASH sources.
    *
    * @remarks
-   * <br/> - Available since v2.47.0.
    * <br/> - The time server should return time in ISO-8601 format.
    * <br/> - Overrides the time server provided the DASH manifest's `<UTCTiming>`.
    * <br/> - Only this source will use the time server. Alternatively, for all source use {@link SourceConfiguration.timeServer}.
@@ -328,7 +327,6 @@ export interface BaseSource {
    *
    * @remarks
    * <br/> - This setting must be `true` when using Low-Latency CMAF with ABR.
-   * <br/> - Available since v2.62.0.
    */
   lowLatency?: boolean;
 
@@ -336,7 +334,6 @@ export interface BaseSource {
    * The configuration for controlling playback of an MPEG-DASH stream.
    *
    * @remarks
-   * <br/> - Available since v2.79.0.
    * <br/> - Ignored for non-DASH streams.
    */
   dash?: DashPlaybackConfiguration;
@@ -345,7 +342,6 @@ export interface BaseSource {
    * The configuration for controlling playback of an HLS stream.
    *
    * @remarks
-   * <br/> - Available since v2.82.0.
    * <br/> - Ignored for non-HLS streams.
    */
   hls?: HlsPlaybackConfiguration;
@@ -371,7 +367,6 @@ export interface TypedSource extends BaseSource {
    *
    * @remarks
    * <br/> - Required if the `ssai` property is absent.
-   * <br/> - Available since v2.4.0.
    */
   src?: string;
 
@@ -381,17 +376,11 @@ export interface TypedSource extends BaseSource {
    * <br/> - `'application/x-mpegURL'` or `'application/vnd.apple.mpegurl'`: The media resource is an HLS stream.
    * <br/> - `'video/mp4'`, `'video/webm'` and other formats: The media resource should use native HTML5 playback if supported by the browser.
    * <br/> - `'application/vnd.theo.hesp+json'`: The media resource is an HESP stream.
-   *
-   * @remarks
-   * <br/> - Available since v2.4.0.
    */
   type?: string;
 
   /**
    * The content protection parameters for the media resource.
-   *
-   * @remarks
-   * <br/> - Available since v2.15.0.
    */
   contentProtection?: DRMConfiguration;
 
@@ -407,9 +396,6 @@ export interface TypedSource extends BaseSource {
 
   /**
    * The Server-side Ad Insertion parameters for the media resource.
-   *
-   * @remarks
-   * <br/> - Available since v2.12.0.
    */
   ssai?: ServerSideAdInsertionConfiguration;
 }

--- a/src/api/source/SourceDescription.ts
+++ b/src/api/source/SourceDescription.ts
@@ -54,8 +54,7 @@ export enum SourceIntegrationId {
 /**
  * The playback pipeline to use to play a stream.
  *
- * @remarks
- * <br/> - Available on Android only.
+ * @platform android
  */
 export enum PlaybackPipeline {
   LEGACY = 'legacy',
@@ -262,8 +261,7 @@ export interface TextTrackDescription {
    *
    * @internal
    *
-   * @remarks
-   * <br/> - Available on iOS.
+   * @platform ios
    */
   subtitlePTS?: string;
 
@@ -271,8 +269,10 @@ export interface TextTrackDescription {
    * The localTime that matches the PTS value that is used to sync the track with the video.
    *
    * @internal
+   *
+   * @platform ios
+   *
    * @remarks
-   * <br/> - Available on iOS.
    * <br/> - Format: "HH:mm:mm:SSS"
    * <br/> - Default value is "00:00:00:000"
    */
@@ -304,8 +304,7 @@ export interface BaseSource {
    * The offset in seconds used to determine the live point.
    * This live point is the end of the manifest minus the provided offset.
    *
-   * @remarks
-   * <br/> - Available on Web and Android.
+   * @platform web,android
    *
    * @defaultValue Three times the segment's target duration.
    */
@@ -356,8 +355,7 @@ export interface BaseSource {
    *
    * @defaultValue [PlaybackPipeline.MEDIA3]
    * @since v9.0.0
-   * @remarks
-   * <br/> - Available on Android only.
+   * @platform android
    */
   playbackPipeline?: PlaybackPipeline;
 }
@@ -400,8 +398,9 @@ export interface TypedSource extends BaseSource {
   /**
    * The headers included in the request when retrieving the resource.
    *
+   * @platform ios,android
+   *
    * @remarks
-   * <br/> - Available on iOS and Android.
    * <br/> - Available since v7.9.0.
    */
   headers?: { [key: string]: string };

--- a/src/api/source/ads/Ads.ts
+++ b/src/api/source/ads/Ads.ts
@@ -78,7 +78,6 @@ export interface AdDescription {
    * @remarks
    * <br/> - A timestamp which is not in the playback window will result in the ad break not being started.
    * <br/> - VMAP resources will ignore this value as they contain an internal offset.
-   * <br/> - Since 2.18, numbers are supported for the Google IMA integration, since 2.21 other formats as well.
    *
    * @defaultValue `'start'`
    *

--- a/src/api/source/ads/TheoAdDescription.ts
+++ b/src/api/source/ads/TheoAdDescription.ts
@@ -75,9 +75,10 @@ export interface TheoAdDescription extends AdDescription {
   /**
    * The streamActivityMonitorId added to the GAM Pod stream request.
    *
+   * @platform web
+   *
    * @remarks
    * <br/> - Available since v8.17.0.
-   * <br/> - Available on Web only.
    */
   streamActivityMonitorId?: string;
 

--- a/src/api/source/ads/TheoAdDescription.ts
+++ b/src/api/source/ads/TheoAdDescription.ts
@@ -77,8 +77,7 @@ export interface TheoAdDescription extends AdDescription {
    *
    * @platform web
    *
-   * @remarks
-   * <br/> - Available since v8.17.0.
+   * @since React Native THEOplayer SDK v8.17.0.
    */
   streamActivityMonitorId?: string;
 

--- a/src/api/source/ads/ssai/GoogleDAIConfiguration.ts
+++ b/src/api/source/ads/ssai/GoogleDAIConfiguration.ts
@@ -71,10 +71,11 @@ export interface GoogleDAIConfiguration extends ServerSideAdInsertionConfigurati
     /**
      * The network code for the publisher making this stream request.
      *
+     * @platform web
+     *
      * @remarks
      * <br/> - See {@link https://developers.google.com/ad-manager/dynamic-ad-insertion/sdk/html5/reference/js/StreamRequest#networkCode}
      *         for more information.
-     * <br/> - Available on Web only.
      */
     networkCode?: string;
 }

--- a/src/api/source/cmcd/CmcdConfiguration.ts
+++ b/src/api/source/cmcd/CmcdConfiguration.ts
@@ -6,16 +6,14 @@ export interface CmcdConfiguration {
   /**
    * The content ID parameter which should be passed as a CMCD value. If left empty, no content ID will be sent.
    *
-   * @remarks
-   * Web only
+   * @platform web
    */
   contentID?: string;
 
   /**
    * The session ID parameter which should be passed as a CMCD value. If left empty, a UUIDv4 will be generated when applying the configuration.
    *
-   * @remarks
-   * Web only
+   * @platform web
    */
   sessionID?: string;
 
@@ -23,8 +21,7 @@ export interface CmcdConfiguration {
    * A flag to indicate if request IDs should be sent or not.
    * When set to a truthy value, a UUIDv4 will be sent as a request id (`rid`) with every request to allow for request tracing.
    *
-   * @remarks
-   * Web only
+   * @platform web
    */
   sendRequestID?: boolean;
 
@@ -32,8 +29,7 @@ export interface CmcdConfiguration {
    * The target URI where client data is to be delivered in case the {@link transmissionMode} is set
    * to {@link CmcdTransmissionMode.JSON_OBJECT}.
    *
-   * @remarks
-   * Web only
+   * @platform web
    */
   jsonObjectTargetURI?: string;
 
@@ -42,8 +38,7 @@ export interface CmcdConfiguration {
    * Note custom keys MUST carry a hyphenated prefix to ensure that there will not be a namespace collision with future
    * revisions to the specification. Clients SHOULD use a reverse-DNS syntax when defining their own prefix.
    *
-   * @remarks
-   * Web only
+   * @platform web
    */
   customKeys?: {
     [key: string]: string | number | boolean;

--- a/src/api/source/dash/DashPlaybackConfiguration.ts
+++ b/src/api/source/dash/DashPlaybackConfiguration.ts
@@ -15,9 +15,6 @@ export type SeamlessPeriodSwitchStrategy = 'auto' | 'always' | 'never';
 /**
  * Represents a configuration for controlling playback of an MPEG-DASH stream.
  *
- * @remarks
- * <br/> - Available since v2.79.0.
- *
  * @public
  */
 export interface DashPlaybackConfiguration {
@@ -51,7 +48,6 @@ export interface DashPlaybackConfiguration {
    * @platform android
    *
    * @remarks
-   * <br/> - Available since v4.1.0.
    * <br/> - On certain smart TV platforms (such as Tizen 2), playback issues may arise when
    *         the timescale of the media data changes across periods or discontinuities.
    *         In that case, the player may need to shift all the timescales first,
@@ -69,7 +65,6 @@ export interface DashPlaybackConfiguration {
    * @platform web
    *
    * @remarks
-   * <br/> - Available since v4.11.0.
    * <br/> - When specified, if the player decides to shift the timescale (see {@link DashPlaybackConfiguration.needsTimescaleShifting}), the timescale will be set to the
    *         given desired timescale.
    * <br/> - When not specified, if the player decides to shift timescale, the player will decide the timescale to which it should shift.
@@ -94,7 +89,6 @@ export interface DashPlaybackConfiguration {
    * @platform web,android
    *
    * @remarks
-   * <br/> - Available since v5.2.0.
    * <br/> - This only applies to livestreams (with `<MPD type="dynamic">`).
    * <br/> - This only applies to streams that use `<SegmentTimeline>`.
    */

--- a/src/api/source/dash/DashPlaybackConfiguration.ts
+++ b/src/api/source/dash/DashPlaybackConfiguration.ts
@@ -24,8 +24,7 @@ export interface DashPlaybackConfiguration {
   /**
    * Whether to seamlessly switch between DASH periods.
    *
-   * @remarks
-   * <br/> - Available on Web only.
+   * @platform web
    *
    * The player supports two strategies for handling a switch between two periods in an MPEG-DASH stream:
    * <br/> - <strong>Seamless</strong>: Once the player is done buffering the current period, it immediately starts buffering the next period.
@@ -49,9 +48,10 @@ export interface DashPlaybackConfiguration {
    * (Experimental) Whether the timescales of the media data need to be shifted,
    * in order to work around platform-specific issues on certain smart TV platforms.
    *
+   * @platform android
+   *
    * @remarks
    * <br/> - Available since v4.1.0.
-   * <br/> - Available on Web only.
    * <br/> - On certain smart TV platforms (such as Tizen 2), playback issues may arise when
    *         the timescale of the media data changes across periods or discontinuities.
    *         In that case, the player may need to shift all the timescales first,
@@ -66,9 +66,10 @@ export interface DashPlaybackConfiguration {
   /**
    * (Experimental) The desired timescale to which the media data should be shifted.
    *
+   * @platform web
+   *
    * @remarks
    * <br/> - Available since v4.11.0.
-   * <br/> - Available on Web only.
    * <br/> - When specified, if the player decides to shift the timescale (see {@link DashPlaybackConfiguration.needsTimescaleShifting}), the timescale will be set to the
    *         given desired timescale.
    * <br/> - When not specified, if the player decides to shift timescale, the player will decide the timescale to which it should shift.
@@ -82,8 +83,7 @@ export interface DashPlaybackConfiguration {
    *
    * @internal
    *
-   * @remarks
-   * <br/> - Available on Web only.
+   * @platform web
    */
   forceSeekToSynchronize?: boolean;
 
@@ -91,9 +91,10 @@ export interface DashPlaybackConfiguration {
    * (Experimental) Force the player to ignore the availability window of individual segments in the MPD,
    * and instead consider every listed segment to be immediately available.
    *
+   * @platform web,android
+   *
    * @remarks
    * <br/> - Available since v5.2.0.
-   * <br/> - Available on Web and Android.
    * <br/> - This only applies to livestreams (with `<MPD type="dynamic">`).
    * <br/> - This only applies to streams that use `<SegmentTimeline>`.
    */
@@ -102,10 +103,9 @@ export interface DashPlaybackConfiguration {
   /**
    * A flag to indicate whether timestamps of segmented WebVTT subtitles are relative to the segment start time.
    *
-   * @remarks
-   * <br/> - Available on Web only.
+   * @platform web
    *
-   *  @defaultValue `true`
+   * @defaultValue `true`
    */
   segmentRelativeVttTiming?: boolean;
 }

--- a/src/api/source/hls/HlsPlaybackConfiguration.ts
+++ b/src/api/source/hls/HlsPlaybackConfiguration.ts
@@ -23,9 +23,6 @@ export type HlsDiscontinuityAlignment = 'auto' | 'playlist' | 'media';
 /**
  * Represents a configuration for controlling playback of an MPEG-DASH stream.
  *
- * @remarks
- * <br/> - Available since v2.82.0.
- *
  * @public
  */
 export interface HlsPlaybackConfiguration {

--- a/src/api/theoads/TheoAdsAPI.ts
+++ b/src/api/theoads/TheoAdsAPI.ts
@@ -3,8 +3,7 @@ import { Interstitial } from './interstitial/Interstitial';
 /**
  * The THEOads API.
  *
- * @remarks
- * <br/> - Available since v8.17.0.
+ * @since React Native THEOplayer SDK v8.17.0.
  *
  * @category THEOads
  * @public

--- a/src/api/theolive/TheoLiveConfiguration.ts
+++ b/src/api/theolive/TheoLiveConfiguration.ts
@@ -7,32 +7,28 @@ export interface TheoLiveConfiguration {
   /**
    * An id used to report usage analytics, if not explicitly given a random UUID is used.
    *
-   * @remarks
-   * <br/> - Available on Web and Android only.
+   * @platform web,android
    */
   readonly externalSessionId?: string;
 
   /**
    * Whether this player should fallback or not when it has a fallback configured.
    *
-   * @remarks
-   * <br/> - Available on Web only.
+   * @platform web
    */
   readonly fallbackEnabled?: boolean;
 
   /**
    * An optional header that can be passed during discovery.
    *
-   * @remarks
-   * <br/> - Available on Web only.
+   * @platform web
    */
   readonly discoveryHeader?: string;
 
   /**
    * Whether THEOlive analytics should be disabled or not.
    *
-   * @remarks
-   * <br/> - Available on Android only.
+   * @platform android
    *
    * @defaultValue `false`
    */

--- a/src/api/track/TextTrackStyle.ts
+++ b/src/api/track/TextTrackStyle.ts
@@ -15,7 +15,7 @@ export interface TextTrackStyle {
    * @example
    * <br/> - `red` will set the color of the text to red.
    * <br/> - `#ff0000` will set the color of the text to red.
-   * <br/> - Available on Web only: `rgba(255,0,0,0.5)` will set the color of the text to red, with 50% opacity.
+   * <br/> - Available for Web only: `rgba(255,0,0,0.5)` will set the color of the text to red, with 50% opacity.
    */
   fontColor: string | undefined;
 
@@ -36,21 +36,22 @@ export interface TextTrackStyle {
    * @example
    * <br/> - `red` will set the background color of the text track to red.
    * <br/> - `#ff0000` will set the background color of the text track to red.
-   * <br/> - Available on Web only: `rgba(255,0,0,0.5)` will set the background color of the text track to red, with 50% opacity.
+   * <br/> - Available for Web only: `rgba(255,0,0,0.5)` will set the background color of the text track to red, with 50% opacity.
    */
   backgroundColor: string | undefined;
 
   /**
    * The window color for the text track.
    *
+   * @platform web,android
+   *
    * @remarks
    * <br/> - This targets the area covering the full width of the text track.
-   * <br/> - Available on Web and Android only.
    *
    * @example
    * <br/> - `red` will set the background color of the window of the text track to red.
    * <br/> - `#ff0000` will set the background color of the window of the text track to red.
-   * <br/> - Available on Web only: `rgba(255,0,0,0.5)` will set the background color of the window of the text track to red, with 50% opacity.
+   * <br/> - Available for Web only: `rgba(255,0,0,0.5)` will set the background color of the window of the text track to red, with 50% opacity.
    */
   windowColor: string | undefined;
 
@@ -67,8 +68,7 @@ export interface TextTrackStyle {
   /**
    * The edge color for the text track.
    *
-   * @remarks
-   * <br/> - Available on Android only.
+   * @platform android
    */
   edgeColor: string | undefined;
 
@@ -83,9 +83,10 @@ export interface TextTrackStyle {
   /**
    * The bottom margin of the area where subtitles are being rendered.
    *
+   * @platform web,android
+   *
    * @remarks
    * <br/> - The margin is in number of pixels.
-   * <br/> - Available on Web and Android only.
    */
   marginBottom: number | undefined;
   /**
@@ -98,10 +99,11 @@ export interface TextTrackStyle {
   /**
    * The right margin  of the area where subtitles are being rendered.
    *
+   * @platform web,android
+   *
    * @remarks
    * <br/> - The margin is in number of pixels.
    * <br/> - Useful for pushing the subtitles left, so they don't overlap with the UI.
-   * <br/> - Available on Web and Android only.
    */
   marginRight: number | undefined;
 }


### PR DESCRIPTION
Use typedoc `@platform` tags instead of comments in API documentation.