### PR TITLE
Add flag to set focusSkipButtonWhenAvailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Added, for HLS on iOS, the unlocalizedLabel to the text-, audio- and videoTracks API, which contains the unmodified label as extracted from the manifest.
+- Added a flag `focusSkipButtonWhenAvailable` to `GoogleImaConfiguration`.
 
 ## [9.5.0] - 25-06-20
 

--- a/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
+++ b/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
@@ -27,6 +27,7 @@ private const val PROP_CAST_CONFIGURATION = "cast"
 private const val PROP_ADS_CONFIGURATION = "ads"
 private const val PROP_IMA_CONFIGURATION = "ima"
 private const val PROP_IMA_AD_LOAD_TIMEOUT = "adLoadTimeout"
+private const val PROP_IMA_FOCUS_SKIP_BUTTON_WHEN_AVAILABLE = "focusSkipButtonWhenAvailable"
 private const val PROP_MEDIA_CONTROL = "mediaControl"
 private const val PROP_PPID = "ppid"
 private const val PROP_MAX_REDIRECTS = "maxRedirects"
@@ -175,6 +176,10 @@ class PlayerConfigAdapter(private val configProps: ReadableMap?) {
         // we unify the prop from javascript by multiplying it by 1000 here
         if (hasKey(PROP_IMA_AD_LOAD_TIMEOUT)) {
           setLoadVideoTimeout(getInt(PROP_IMA_AD_LOAD_TIMEOUT) * 1000)
+        }
+
+        if (hasKey(PROP_IMA_FOCUS_SKIP_BUTTON_WHEN_AVAILABLE)) {
+          focusSkipButtonWhenAvailable = getBoolean(PROP_IMA_FOCUS_SKIP_BUTTON_WHEN_AVAILABLE)
         }
       }
     }

--- a/src/api/ads/GoogleImaConfiguration.ts
+++ b/src/api/ads/GoogleImaConfiguration.ts
@@ -62,4 +62,14 @@ export interface GoogleImaConfiguration {
    * This value will be specified in seconds.
    */
   adLoadTimeout?: number;
+
+
+  /**
+   * Whether to focus on the skip button when the skippable ad can be skipped on Android TV. This is a no-op on non-Android TV devices.
+   * 
+   * @defaultValue `false`
+   * 
+   * @platform android
+   */
+  focusSkipButtonWhenAvailable?: boolean
 }

--- a/src/api/ads/GoogleImaConfiguration.ts
+++ b/src/api/ads/GoogleImaConfiguration.ts
@@ -67,7 +67,7 @@ export interface GoogleImaConfiguration {
   /**
    * Whether to focus on the skip button when the skippable ad can be skipped on Android TV. This is a no-op on non-Android TV devices.
    * 
-   * @defaultValue `false`
+   * @defaultValue `true`
    * 
    * @platform android
    */


### PR DESCRIPTION
PR to add a flag to GoogleImaConfiguration to allow setting focusSkipButtonWhenAvailable for Android TV