### PR TITLE
Fix/ Handling orientation changes in Swift in addition to Dimensions change event

### DIFF
--- a/ios/THEOplayerRCTBridge.m
+++ b/ios/THEOplayerRCTBridge.m
@@ -43,6 +43,7 @@ RCT_EXPORT_VIEW_PROPERTY(onNativeTextTrackListEvent, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativeTextTrackEvent, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativeMediaTrackListEvent, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativeMediaTrackEvent, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onNativeOrientationChanged, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativePlayerReady, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativePresentationModeChange, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativeResize, RCTDirectEventBlock);

--- a/ios/THEOplayerRCTView.swift
+++ b/ios/THEOplayerRCTView.swift
@@ -234,6 +234,14 @@ public class THEOplayerRCTView: UIView {
         self.onNativePlayerReady = nativePlayerReady
         if DEBUG_VIEW { PrintUtils.printLog(logText: "[NATIVE] nativePlayerReady prop set.") }
     }
+  
+    // MARK: - Orientation changed event bridging
+  
+    @objc(setOnNativeOrientationChanged:)
+    func setOnNativeOrientationChanged(nativeOrientationChanged: @escaping RCTDirectEventBlock) {
+        self.presentationModeManager.onNativeOrientationChanged = nativeOrientationChanged
+        if DEBUG_VIEW { PrintUtils.printLog(logText: "[NATIVE] nativeOrientationChanged prop set.") }
+    }
     
     // MARK: - Listener based MAIN event bridging
     

--- a/src/internal/THEOplayerView.tsx
+++ b/src/internal/THEOplayerView.tsx
@@ -78,6 +78,7 @@ interface THEOplayerRCTViewProps {
   ref: React.RefObject<THEOplayerViewNativeComponent | null>;
   style?: StyleProp<ViewStyle>;
   config?: PlayerConfiguration;
+  onNativeOrientationChanged: () => void;
   onNativePlayerReady: (event: NativeSyntheticEvent<NativePlayerStateEvent>) => void;
   onNativeSourceChange: () => void;
   onNativeLoadStart: () => void;
@@ -395,6 +396,7 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
           ref={this._root}
           style={StyleSheet.absoluteFill}
           config={config || {}}
+          onNativeOrientationChanged={this._onDimensionsChanged}
           onNativePlayerReady={this._onNativePlayerReady}
           onNativeSourceChange={this._onSourceChange}
           onNativeLoadStart={this._onLoadStart}


### PR DESCRIPTION
**Summary**:
Dimensions change event doesn't trigger the first time after fullscreen/native reparenting, I think because of some lazy nature of New Architecture tree. It leads to incorrect video formatting in some cases on iOS (see test plan for instance but there're more of them). It doesn't happen in example app and I suspect it occurs in more complex RN UIs.
So in addition to Dimensions event handling we re-layout the player view on iOs physical orientation changed event.

**Test-Plan**:
1. Run the New Arch app on iPad in landscape orientation. DON'T rotate it before you open VOD in fullscreen
2. Open player in some navigation modal
3. Switch to fullscreen
4. Rotate your device to to portrait
5. Expected: the video format looks correct