### PR TITLE
feature/web support aspect-ratio 16/9 in older versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Fixed an issue on Web in case the `aspect-ratio` CSS property is not supported on older browsers.
 - Prevented passing infinite or NaN for intializationDelay in TheoAdDescription, on the Android bridge.
 - 
 ### Added

--- a/src/internal/THEOplayerView.web.tsx
+++ b/src/internal/THEOplayerView.web.tsx
@@ -58,7 +58,8 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
     // It's necessary to make sure we do not interfere with the IMA container
     <div id={'theoplayer-root-container'} style={{ display: 'contents' }}>
       {!CSS.supports('aspect-ratio', '16/9') ? (
-        // Handle aspect-ratio 16/9 with padding-top: 56.25% to support older versions
+        // Handle aspect-ratio 16/9 with padding-top: 56.25% to support older versions.
+        // {@link https://www.w3schools.com/howto/howto_css_aspect_ratio.asp}
         <div style={styles.containerNoAspectRatio}>
           <div ref={container} style={styles.absoluteFillNoAspectRatio} className="theoplayer-container" />
         </div>

--- a/src/internal/THEOplayerView.web.tsx
+++ b/src/internal/THEOplayerView.web.tsx
@@ -55,8 +55,8 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
   if (!CSS.supports('aspect-ratio', '16/9')) {
     return (
       <div id={'theoplayer-root-container'} style={{ display: 'contents' }}>
-        <div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>
-          <div ref={container} style={{ position: 'absolute', top: 0, left: 0, bottom: 0, right: 0, width: '100%', height: '100%' }} />
+        <div style={styles.containerNoAspectRatio}>
+          <div ref={container} style={styles.absoluteFillNoAspectRatio} />
         </div>
         {children}
       </div>
@@ -85,5 +85,19 @@ const styles = {
     maxHeight: '100vh',
     maxWidth: '100vw',
     aspectRatio: '16 / 9',
+  } as React.CSSProperties,
+  containerNoAspectRatio: {
+    width: '100%',
+    position: 'relative',
+    paddingTop: '56.25%',
+  } as React.CSSProperties,
+  absoluteFillNoAspectRatio: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0,
+    width: '100%',
+    height: '100%',
   } as React.CSSProperties,
 };

--- a/src/internal/THEOplayerView.web.tsx
+++ b/src/internal/THEOplayerView.web.tsx
@@ -60,7 +60,7 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
       {!CSS.supports('aspect-ratio', '16/9') ? (
         // Handle aspect-ratio 16/9 with padding-top: 56.25% to support older versions
         <div style={styles.containerNoAspectRatio}>
-          <div ref={container} style={styles.absoluteFillNoAspectRatio} />
+          <div ref={container} style={styles.absoluteFillNoAspectRatio} className="theoplayer-container" />
         </div>
       ) : (
         <div ref={container} style={styles.container} className="theoplayer-container" />

--- a/src/internal/THEOplayerView.web.tsx
+++ b/src/internal/THEOplayerView.web.tsx
@@ -52,6 +52,17 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
     };
   }, [container]);
 
+  if (!CSS.supports('aspect-ratio', '16/9')) {
+    return (
+      <div id={'theoplayer-root-container'} style={{ display: 'contents' }}>
+        <div style={{ width: '100%', position: 'relative', paddingTop: '56.25%' }}>
+          <div ref={container} style={{ position: 'absolute', top: 0, left: 0, bottom: 0, right: 0, width: '100%', height: '100%' }} />
+        </div>
+        {children}
+      </div>
+    );
+  }
+
   return (
     // Note: display: contents causes an element's children to appear as if they were direct children of the element's parent,
     // ignoring the element itself.

--- a/src/internal/THEOplayerView.web.tsx
+++ b/src/internal/THEOplayerView.web.tsx
@@ -52,23 +52,19 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
     };
   }, [container]);
 
-  if (!CSS.supports('aspect-ratio', '16/9')) {
-    return (
-      <div id={'theoplayer-root-container'} style={{ display: 'contents' }}>
-        <div style={styles.containerNoAspectRatio}>
-          <div ref={container} style={styles.absoluteFillNoAspectRatio} />
-        </div>
-        {children}
-      </div>
-    );
-  }
-
   return (
-    // Note: display: contents causes an element's children to appear as if they were direct children of the element's parent,
+    // Note: `display: contents` causes an element's children to appear as if they were direct children of the element's parent,
     // ignoring the element itself.
     // It's necessary to make sure we do not interfere with the IMA container
     <div id={'theoplayer-root-container'} style={{ display: 'contents' }}>
-      <div ref={container} style={styles.container} className={'theoplayer-container'} />
+      {!CSS.supports('aspect-ratio', '16/9') ? (
+        // Handle aspect-ratio 16/9 with padding-top: 56.25% to support older versions
+        <div style={styles.containerNoAspectRatio}>
+          <div ref={container} style={styles.absoluteFillNoAspectRatio} />
+        </div>
+      ) : (
+        <div ref={container} style={styles.container} className="theoplayer-container" />
+      )}
       {children}
     </div>
   );


### PR DESCRIPTION
Add validation to handle aspect-ratio 16/9 with padding-top: 56.25% to support older versions