### PR TITLE
Fix/ Android PiP: hide player siblings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue on Android where the app could still enter picture-in-picture presentation mode after closing the player.
+
 ### Changed
 
 - Upgraded the example app to React-Native v0.81.
+- All child views of `<THEOplayerView>` are being hidden when transitioning to picture-in-picture presentation mode on Android.
 
 ## [9.10.0] - 25-08-19
 

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -162,7 +162,7 @@ class PresentationManager(
     }
   }
 
-  private fun setSecondaryChildrenVisibility(visible: Boolean) = reactPlayerGroup?.children?.forEach {
+  private fun setPlayerSiblingsVisibility(visible: Boolean) = reactPlayerGroup?.children?.forEach {
     if (it !is ReactTHEOplayerView) {
       it.visibility = if (visible) View.VISIBLE else View.INVISIBLE
     }
@@ -173,7 +173,7 @@ class PresentationManager(
    * or after it ends (transitioningToPip = false)
    */
   private fun onEnterPip(transitioningToPip: Boolean = false) {
-    setSecondaryChildrenVisibility(false)
+    setPlayerSiblingsVisibility(false)
     if (BuildConfig.REPARENT_ON_PIP && !transitioningToPip && pipConfig.reparentPip == true) {
       reparentPlayerToRoot()
     }
@@ -189,7 +189,7 @@ class PresentationManager(
    * Called when the PiP exit transition starts.
    */
   private fun onExitPip() {
-    setSecondaryChildrenVisibility(true)
+    setPlayerSiblingsVisibility(true)
     val pipCtx: PresentationModeChangePipContext =
       if ((reactContext.currentActivity as? ComponentActivity)?.lifecycle?.currentState == Lifecycle.State.CREATED) {
         PresentationModeChangePipContext.CLOSED

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -22,6 +22,7 @@ import com.facebook.react.views.view.ReactViewGroup
 import com.theoplayer.BuildConfig
 import com.theoplayer.PlayerEventEmitter
 import com.theoplayer.ReactTHEOplayerContext
+import com.theoplayer.ReactTHEOplayerView
 import com.theoplayer.android.api.error.ErrorCode
 import com.theoplayer.android.api.error.THEOplayerException
 import com.theoplayer.android.api.player.PresentationMode
@@ -161,11 +162,18 @@ class PresentationManager(
     }
   }
 
+  private fun setSecondaryChildrenVisibility(visible: Boolean) = reactPlayerGroup?.children?.forEach {
+    if (it !is ReactTHEOplayerView) {
+      it.visibility = if (visible) View.VISIBLE else View.INVISIBLE
+    }
+  }
+
   /**
    * Called when the transition into PiP either starts (transitioningToPip = true)
    * or after it ends (transitioningToPip = false)
    */
   private fun onEnterPip(transitioningToPip: Boolean = false) {
+    setSecondaryChildrenVisibility(false)
     if (BuildConfig.REPARENT_ON_PIP && !transitioningToPip && pipConfig.reparentPip == true) {
       reparentPlayerToRoot()
     }
@@ -181,6 +189,7 @@ class PresentationManager(
    * Called when the PiP exit transition starts.
    */
   private fun onExitPip() {
+    setSecondaryChildrenVisibility(true)
     val pipCtx: PresentationModeChangePipContext =
       if ((reactContext.currentActivity as? ComponentActivity)?.lifecycle?.currentState == Lifecycle.State.CREATED) {
         PresentationModeChangePipContext.CLOSED


### PR DESCRIPTION
**Description:**

To fix a New Architecture related issue. As we discussed earlier on Android it suspends the JS thread updates. If user of RN-theoplayer lib renders any views within THEOplayerView children it won't hide it where the app is moved to background/PiP.

**Test-plan:**
1. Open the test app where you have some views (e.g. playback controls) rendered as direct children of `<THEOplayerView />` in JS code.
2. Play video
3. Move the app to BG to show video in PiP mode
4. Expected: it should hide any sibling of player in PiP. 