### PR TITLE
Fix/ Android: PresentationManager destroy()

### DIFF
--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -113,7 +113,7 @@ class PresentationManager(
       reactContext.currentActivity?.let { activity ->
         onUserLeaveHintReceiver?.let { activity.unregisterReceiver(it) }
         (activity as? ComponentActivity)?.removeOnUserLeaveHintListener(onUserLeaveHintRunnable)
-        onPictureInPictureModeChanged?.let{ activity.unregisterReceiver(it) }
+        onPictureInPictureModeChanged?.let { activity.unregisterReceiver(it) }
       }
 
       fullScreenLayoutObserver.remove()

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -112,7 +112,7 @@ class PresentationManager(
     try {
       reactContext.currentActivity?.let { activity ->
         onUserLeaveHintReceiver?.let { activity.unregisterReceiver(it) }
-        (activity as? ComponentActivity)?.removeOnUserLeaveHintListener (onUserLeaveHintRunnable)
+        (activity as? ComponentActivity)?.removeOnUserLeaveHintListener(onUserLeaveHintRunnable)
         onPictureInPictureModeChanged?.let{ activity.unregisterReceiver(it) }
       }
 

--- a/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
+++ b/android/src/main/java/com/theoplayer/presentation/PresentationManager.kt
@@ -111,9 +111,9 @@ class PresentationManager(
   fun destroy() {
     try {
       reactContext.currentActivity?.let { activity ->
-        activity.unregisterReceiver(onUserLeaveHintReceiver)
-        (activity as? ComponentActivity)?.addOnUserLeaveHintListener(onUserLeaveHintRunnable)
-        activity.unregisterReceiver(onPictureInPictureModeChanged)
+        onUserLeaveHintReceiver?.let { activity.unregisterReceiver(it) }
+        (activity as? ComponentActivity)?.removeOnUserLeaveHintListener (onUserLeaveHintRunnable)
+        onPictureInPictureModeChanged?.let{ activity.unregisterReceiver(it) }
       }
 
       fullScreenLayoutObserver.remove()


### PR DESCRIPTION
**Summary:**
[This PR](https://github.com/THEOplayer/react-native-theoplayer/pull/620/files) seems to introduce a new issue where the PresentationManager::destroy() does the following

- throws exception at nullish onUserLeaveHintRunnable and doesn't finish running itself
- calls addOnUserLeaveHintListener instead of calling appropriate remove listener

It leads to the situations where the player component was destroyed but the PiP mode still can be entered.

**Test-Plan:**

1. Run the Android app
2. Watch player
3. Close it
4. Move to BG
5. Expected - no unexpected PiP. The method destroy() is finished successfully.