### PR TITLE
maintenance/update-migration-guide

### DIFF
--- a/doc/migrating-to-react-native-theoplayer-10.md
+++ b/doc/migrating-to-react-native-theoplayer-10.md
@@ -41,6 +41,16 @@ was also removed.
 The `PlaybackSettingsAPI`, which allowed to control start-up and lip sync correction on the legacy
 pipeline, has been removed.
 
+### Update `compileSdk` to 36 or higher
+
+The underlying Android SDK depends on the AndroidX Core library, which requires `compileSdk 36` as of
+version 1.17.0.
+
+Update the `compileSdk` to be `36` (or higher) in your module-level `build.gradle` file.
+
+We also recommend updating the Android Gradle Plugin to the latest version. In Android Studio, go to
+Tools → AGP Upgrade Assistant and follow the steps to update AGP in your project.
+
 ### Updated `minSdk` to API 23 on Android
 
 This aligns with [other Android Jetpack libraries requiring API 23 as of June 2025](https://developer.android.com/jetpack/androidx/versions#version-table).

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -84,10 +84,12 @@ export default function App() {
     player.addEventListener(PlayerEventType.READYSTATE_CHANGE, console.log);
     player.addEventListener(PlayerEventType.PLAY, console.log);
     player.addEventListener(PlayerEventType.PLAYING, console.log);
+    player.addEventListener(PlayerEventType.WAITING, console.log);
     player.addEventListener(PlayerEventType.PAUSE, console.log);
     player.addEventListener(PlayerEventType.SEEKING, console.log);
     player.addEventListener(PlayerEventType.SEEKED, console.log);
     player.addEventListener(PlayerEventType.ENDED, console.log);
+    player.addEventListener(PlayerEventType.ERROR, console.log);
     player.addEventListener(PlayerEventType.THEOLIVE_EVENT, console.log);
 
     sdkVersions().then((versions) => console.log(`[theoplayer] ${JSON.stringify(versions, null, 4)}`));


### PR DESCRIPTION
This PR updates the migration guide to mention the compileSdk 36 requirement of the underlying Android SDK, which can be considered a breaking change since it requires a newer React Native version.