### PR TITLE
Feature/android custom typeface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added an explicit clearing of the NowPlayingInfo on iOS, when the app receives a willTerminateNotification, to make sure all NowPlayingInfo is removed from the lock screen when an app is closed.
 
+- Added `fontPath` to `TextTrackStyle` to allow loading custom fonts from the Android assets folder.
+
 ### Fixed
 
 - Fixed an issue on Android where play-out of Millicast sources in the example app would fail. The Android NDK version needs to be at least v28.

--- a/android/src/main/java/com/theoplayer/player/PlayerModule.kt
+++ b/android/src/main/java/com/theoplayer/player/PlayerModule.kt
@@ -253,7 +253,7 @@ class PlayerModule(context: ReactApplicationContext) : ReactContextBaseJavaModul
   fun setTextTrackStyle(tag: Int, style: ReadableMap?) {
     viewResolver.resolveViewByTag(tag) { view: ReactTHEOplayerView? ->
       view?.player?.let { player ->
-        TextTrackStyleAdapter.applyTextTrackStyle(player.textTrackStyle, style)
+        TextTrackStyleAdapter.applyTextTrackStyle(player.textTrackStyle, reactApplicationContext, style)
       }
     }
   }

--- a/android/src/main/java/com/theoplayer/track/TextTrackStyleAdapter.kt
+++ b/android/src/main/java/com/theoplayer/track/TextTrackStyleAdapter.kt
@@ -1,6 +1,8 @@
 package com.theoplayer.track
 
 import android.graphics.Color
+import android.graphics.Typeface
+import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReadableMap
 import com.theoplayer.android.api.player.track.texttrack.TextTrackStyle
 
@@ -10,6 +12,7 @@ private const val PROP_EDGE_COLOR = "edgeColor"
 private const val PROP_FONT_COLOR = "fontColor"
 private const val PROP_FONT_FAMILY = "fontFamily"
 private const val PROP_FONT_SIZE = "fontSize"
+private const val PROP_FONT_PATH = "fontPath"
 private const val PROP_WINDOW_COLOR = "windowColor"
 private const val PROP_MARGIN_LEFT = "marginLeft"
 private const val PROP_MARGIN_RIGHT = "marginRight"
@@ -22,7 +25,7 @@ private const val PROP_COLOR_A = "a"
 
 object TextTrackStyleAdapter {
 
-  fun applyTextTrackStyle(style: TextTrackStyle, props: ReadableMap?) {
+  fun applyTextTrackStyle(style: TextTrackStyle, context: ReactApplicationContext, props: ReadableMap?) {
     if (props == null) {
       return
     }
@@ -64,6 +67,10 @@ object TextTrackStyleAdapter {
     }
     if (props.hasKey(PROP_MARGIN_RIGHT)) {
       style.marginRight = props.getInt(PROP_MARGIN_RIGHT)
+    }
+    if (props.hasKey(PROP_FONT_PATH)) {
+      val font = Typeface.createFromAsset(context.assets, props.getString(PROP_FONT_PATH))
+      style.font = font
     }
   }
 

--- a/src/api/track/TextTrackStyle.ts
+++ b/src/api/track/TextTrackStyle.ts
@@ -29,6 +29,14 @@ export interface TextTrackStyle {
   fontSize: string | undefined;
 
   /**
+   * The path to a font in the Android `app/src/main/assets/` folder.
+   * 
+   * @remarks
+   * Only supported on Android.
+   */
+  fontPath: string | undefined;
+
+  /**
    * The background color for the text track.
    *
    * @remarks

--- a/src/internal/adapter/track/TextTrackStyleAdapter.ts
+++ b/src/internal/adapter/track/TextTrackStyleAdapter.ts
@@ -12,6 +12,7 @@ export class TextTrackStyleAdapter implements TextTrackStyle {
   private _fontColor: string | undefined = undefined;
   private _fontFamily: string | undefined = undefined;
   private _fontSize: string | undefined = undefined;
+  private _fontPath: string | undefined = undefined;
   private _windowColor: string | undefined = undefined;
   private _marginBottom: number | undefined = undefined;
   private _marginTop: number | undefined = undefined;
@@ -73,6 +74,17 @@ export class TextTrackStyleAdapter implements TextTrackStyle {
     NativePlayerModule.setTextTrackStyle(this._view.nativeHandle, {
       fontFamily: family,
     });
+  }
+
+  get fontPath(): string | undefined {
+    return this._fontPath
+  }
+
+  set fontPath(path: string) {
+    this._fontPath = path
+    NativePlayerModule.setTextTrackStyle(this._view.nativeHandle, {
+      fontPath: path
+    })
   }
 
   get fontSize(): string | undefined {


### PR DESCRIPTION
Small addition to the [Text Track Style API](https://theoplayer.github.io/react-native-theoplayer/api/interfaces/TextTrackStyle.html), to allow for loading custom fonts on Android. 

By placing the font file in `android/app/src/main/assets/`, e.g. 
```
android/
└── app/
    └── src/
        └── main/
            └── assets/
                └── font/
                    └── myfont.ttf
```

referencing it as follows in your app, a custom fonts can be used to render subtitles:

```
player.textTrackStyle.fontPath = "font/myfont.ttf"
```