### PR TITLE
Bugfix/ios crash on destroy from fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed a issue on iOS where the player crashed when it was destroyed while in fullscreen.
+
 ## [10.1.0] - 25-10-06
 
 ### Added

--- a/ios/THEOplayerRCTBridge.m
+++ b/ios/THEOplayerRCTBridge.m
@@ -120,6 +120,8 @@ RCT_EXTERN_METHOD(setTextTrackStyle:(nonnull NSNumber *)node
 RCT_EXTERN_METHOD(setKeepScreenOn:(nonnull NSNumber *)node
                   keepScreenOn:(BOOL)keepScreenOn)
 
+RCT_EXTERN_METHOD(willUnmount:(nonnull NSNumber *)node)
+
 RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(getUsableScreenDimensions)
 
 @end

--- a/ios/THEOplayerRCTPlayerAPI.swift
+++ b/ios/THEOplayerRCTPlayerAPI.swift
@@ -423,4 +423,13 @@ class THEOplayerRCTPlayerAPI: NSObject, RCTBridgeModule {
         if DEBUG_PLAYER_API { PrintUtils.printLog(logText: "[NATIVE] landscape dimensions: \(biggest) - \(smallest)")}
         return ["width": biggest, "height": smallest] // ios landscape or tvos
     }
+    
+    @objc(willUnmount:)
+    func willUnmount(_ node: NSNumber) -> Void {
+        DispatchQueue.main.async {
+            if let theView = self.bridge.uiManager.view(forReactTag: node) as? THEOplayerRCTView {
+                theView.willUnmount()
+            }
+        }
+    }
 }

--- a/ios/THEOplayerRCTView.swift
+++ b/ios/THEOplayerRCTView.swift
@@ -117,6 +117,12 @@ public class THEOplayerRCTView: UIView {
     }
     
     func willUnmount() {
+        // before destruction, make sure the view reparenting is reset when player was put in fullscreen
+        if self.presentationModeManager.presentationMode == .fullscreen {
+            if DEBUG_THEOPLAYER_INTERACTION {PrintUtils.printLog(logText: "[NATIVE] willUnmount with presentationMode: \(self.presentationModeManager.presentationMode._rawValue)")}
+            
+            self.setPresentationMode(newPresentationMode: PresentationMode.inline)
+        }
     }
   
     deinit {

--- a/ios/THEOplayerRCTView.swift
+++ b/ios/THEOplayerRCTView.swift
@@ -115,6 +115,9 @@ public class THEOplayerRCTView: UIView {
     required init?(coder aDecoder: NSCoder) {
         fatalError("[NATIVE] init(coder:) has not been implemented")
     }
+    
+    func willUnmount() {
+    }
   
     deinit {
         self.mainEventHandler.destroy()

--- a/ios/presentationMode/THEOplayerRCTPresentationModeManager.swift
+++ b/ios/presentationMode/THEOplayerRCTPresentationModeManager.swift
@@ -9,7 +9,7 @@ public class THEOplayerRCTPresentationModeManager {
     private weak var player: THEOplayer?
     private weak var view: UIView?
     var presentationModeContext = THEOplayerRCTPresentationModeContext()
-    private var presentationMode: THEOplayerSDK.PresentationMode = .inline
+    private(set) var presentationMode: THEOplayerSDK.PresentationMode = .inline
     private var rnInlineMode: THEOplayerSDK.PresentationMode = .inline // while native player is inline, RN player can be inline or fullsceen
 
   
@@ -178,7 +178,7 @@ public class THEOplayerRCTPresentationModeManager {
         self.presentationMode = newPresentationMode
         // adjust presentationMode to RN layout
         if newPresentationMode == .inline {
-             self.presentationMode = self.rnInlineMode
+            self.presentationMode = self.rnInlineMode
         }
     
         // notify the presentationMode change

--- a/src/internal/THEOplayerView.tsx
+++ b/src/internal/THEOplayerView.tsx
@@ -155,6 +155,9 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
   }
 
   componentWillUnmount() {
+    // Allow proper cleanup on the native player before destruction
+    this._facade.willUnmount();
+
     // Notify the player will be destroyed.
     const { onPlayerDestroy } = this.props;
     if (onPlayerDestroy) {

--- a/src/internal/adapter/THEOplayerAdapter.ts
+++ b/src/internal/adapter/THEOplayerAdapter.ts
@@ -546,4 +546,10 @@ export class THEOplayerAdapter extends DefaultEventDispatcher<PlayerEventMap> im
   get videoHeight(): number | undefined {
     return this._state.videoHeight;
   }
+
+  willUnmount(): void {
+    if (Platform.OS === 'ios') {
+      NativePlayerModule.willUnmount(this._view.nativeHandle);
+    }
+  }
 }


### PR DESCRIPTION
Reproduced by:
- go into fullscreen
- unmount the THEOplayerView form code.

Also:
- set backgroundAudio disabled
- set auto-pip enabled
- go into fullscreen
- move app to background => pip starts
- close pip with close button