### PR TITLE
Safely check for the version

### DIFF
--- a/src/internal/version/Version.ts
+++ b/src/internal/version/Version.ts
@@ -3,8 +3,14 @@ import type { SdkVersions } from 'react-native-theoplayer';
 import * as manifest from '../../manifest.json';
 
 export const sdkVersions = async (): Promise<SdkVersions> => {
-  const rnVersionString = manifest.version ?? '';
-  const nativeVersionString = await NativeModules.THEORCTPlayerModule.version();
+  const rnVersionString = manifest.version ?? 'NA';
+  let nativeVersionString;
+  try {
+    nativeVersionString = await NativeModules.THEORCTPlayerModule.version();
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (_e) {
+    nativeVersionString = 'NA';
+  }
   return {
     rn: rnVersionString,
     native: nativeVersionString,


### PR DESCRIPTION
Add a try-catch clause around accessing `NativeModules.THEORCTPlayerModule`. Some platforms, like Vega, do not provide this module and will crash. They should provide their own `sdkVersions`. 