### PR TITLE
Bugfix/minification proguard missing symbols

### DIFF
--- a/doc/millicast.md
+++ b/doc/millicast.md
@@ -46,6 +46,16 @@ const source: MillicastSource = {
 };
 ```
 
+
+## Note on minification on Android
+
+When adding the Millicast integration into your android project, make sure to add the following keep rule in your `proguard-rules.pro` file:
+```
+-keep class kotlin.** { *; }
+```
+
+Otherwise, you will encounter a `ClassNotFoundException` when attempting to run the application.
+
 ## More information
 
 - [API references](https://theoplayer.github.io/react-native-theoplayer/api/interfaces/MillicastSource.html)

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -58,7 +58,7 @@ react {
 /**
  * Set this to true to Run Proguard on Release builds to minify the Java bytecode.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore (JSC)

--- a/example/android/app/proguard-rules.pro
+++ b/example/android/app/proguard-rules.pro
@@ -8,3 +8,5 @@
 #   http://developer.android.com/guide/developing/tools/proguard.html
 
 # Add any project specific keep options here:
+
+-keep class kotlin.** { *; }


### PR DESCRIPTION
A customer ran into an issue when enabling minification and encountered the following crash: 
```
No pending exception expected: java.lang.ClassNotFoundException: kotlin.ULong 
  at java.lang.String java.lang.Runtime.nativeLoad(java.lang.String, java.lang.ClassLoader, java.lang.Class) (Runtime.java:-2) 
  at void java.lang.Runtime.loadLibrary0(java.lang.ClassLoader, java.lang.Class, java.lang.String) (Runtime.java:1095) 
  at void java.lang.Runtime.loadLibrary0(java.lang.Class, java.lang.String) (Runtime.java:1019) 
  at void java.lang.System.loadLibrary(java.lang.String) (System.java:1765) at void com.millicast.Core.initialize() (SourceFile:14) 
  at void com.theoplayer.android.internal.millicast.b.<clinit>() (SourceFile:9) at
```

This requires integrating applications to add a keep rule for `kotlin.*` classes in their proguard file. This PR introduces it for the example application, enables minification for release builds by default and also adds a note in the documentation.