### PR TITLE
Feature/opti 1010 distribution loaded event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
-- Fixed an issue on iOS where the onPlayerStateSync callback was not called from the main thread.
+- Fixed an issue on iOS where the `onPlayerStateSync` callback was not called from the main thread.
+
+### Added
+
+- Added the `DistributionLoaded` event for THEOlive.
 
 ## [10.9.0] - 26-01-29
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -124,8 +124,8 @@ repositories {
     mavenLocal()
 }
 
-// The minimum supported THEOplayer version is 10.0.1
-def theoVersion = safeExtGet('THEOplayer_sdk', '[10.0.1, 11.0.0)')
+// The minimum supported THEOplayer version is 10.10.0
+def theoVersion = safeExtGet('THEOplayer_sdk', '[10.10.0, 11.0.0)')
 def theoMediaSessionVersion = safeExtGet('THEOplayer_mediasession', '[8.0.0, 11.0.0)')
 def theoAdsWrapperVersion = "10.0.0"
 def coroutinesVersion = safeExtGet('coroutinesVersion', '1.10.2')

--- a/android/src/main/java/com/theoplayer/theolive/THEOliveEventAdapter.kt
+++ b/android/src/main/java/com/theoplayer/theolive/THEOliveEventAdapter.kt
@@ -4,6 +4,7 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.theoplayer.android.api.event.EventListener
 import com.theoplayer.android.api.event.player.theolive.DistributionLoadStartEvent
+import com.theoplayer.android.api.event.player.theolive.DistributionLoadedEvent
 import com.theoplayer.android.api.event.player.theolive.DistributionOfflineEvent
 import com.theoplayer.android.api.event.player.theolive.EndpointLoadedEvent
 import com.theoplayer.android.api.event.player.theolive.IntentToFallbackEvent
@@ -13,6 +14,7 @@ import com.theoplayer.util.PayloadBuilder
 
 private const val EVENT_PROP_TYPE = "type"
 private const val EVENT_PROP_DISTRIBUTION_ID = "distributionId"
+private const val EVENT_PROP_DISTRIBUTION = "distribution"
 private const val EVENT_PROP_ENDPOINT = "endpoint"
 private const val EVENT_PROP_REASON = "reason"
 
@@ -24,6 +26,8 @@ class THEOliveEventAdapter(private val theoLiveApi: TheoLive, private val emitte
 
   private val onDistributionLoadStart =
     EventListener<DistributionLoadStartEvent> { onDistributionLoadStart(it) }
+  private val onDistributionLoaded =
+    EventListener<DistributionLoadedEvent> { onDistributionLoaded(it) }
   private val onDistributionOffline =
     EventListener<DistributionOfflineEvent> { onDistributionOffline(it) }
   private val onEndPointLoaded =
@@ -33,6 +37,7 @@ class THEOliveEventAdapter(private val theoLiveApi: TheoLive, private val emitte
 
   init {
     theoLiveApi.addEventListener(TheoLiveEventTypes.DISTRIBUTIONLOADSTART, onDistributionLoadStart)
+    theoLiveApi.addEventListener(TheoLiveEventTypes.DISTRIBUTIONLOADED, onDistributionLoaded)
     theoLiveApi.addEventListener(TheoLiveEventTypes.DISTRIBUTIONOFFLINE, onDistributionOffline)
     theoLiveApi.addEventListener(TheoLiveEventTypes.ENDPOINTLOADED, onEndPointLoaded)
     theoLiveApi.addEventListener(TheoLiveEventTypes.INTENTTOFALLBACK, onIntentOfFallback)
@@ -43,6 +48,7 @@ class THEOliveEventAdapter(private val theoLiveApi: TheoLive, private val emitte
       TheoLiveEventTypes.DISTRIBUTIONLOADSTART,
       onDistributionLoadStart
     )
+    theoLiveApi.removeEventListener(TheoLiveEventTypes.DISTRIBUTIONLOADED, onDistributionLoaded)
     theoLiveApi.removeEventListener(TheoLiveEventTypes.DISTRIBUTIONOFFLINE, onDistributionOffline)
     theoLiveApi.removeEventListener(TheoLiveEventTypes.ENDPOINTLOADED, onEndPointLoaded)
     theoLiveApi.removeEventListener(TheoLiveEventTypes.INTENTTOFALLBACK, onIntentOfFallback)
@@ -52,6 +58,13 @@ class THEOliveEventAdapter(private val theoLiveApi: TheoLive, private val emitte
     emitter.emit(Arguments.createMap().apply {
       putString(EVENT_PROP_TYPE, "distributionloadstart")
       putString(EVENT_PROP_DISTRIBUTION_ID, event.getDistributionId())
+    })
+  }
+
+  private fun onDistributionLoaded(event: DistributionLoadedEvent) {
+    emitter.emit(Arguments.createMap().apply {
+      putString(EVENT_PROP_TYPE, "distributionloaded")
+      putString(EVENT_PROP_DISTRIBUTION, event.getDistribution())
     })
   }
 

--- a/android/src/main/java/com/theoplayer/theolive/THEOliveEventAdapter.kt
+++ b/android/src/main/java/com/theoplayer/theolive/THEOliveEventAdapter.kt
@@ -17,6 +17,8 @@ private const val EVENT_PROP_DISTRIBUTION_ID = "distributionId"
 private const val EVENT_PROP_DISTRIBUTION = "distribution"
 private const val EVENT_PROP_ENDPOINT = "endpoint"
 private const val EVENT_PROP_REASON = "reason"
+private const val EVENT_PROP_NAME = "name"
+private const val EVENT_PROP_ID = "id"
 
 class THEOliveEventAdapter(private val theoLiveApi: TheoLive, private val emitter: Emitter) {
 
@@ -64,7 +66,10 @@ class THEOliveEventAdapter(private val theoLiveApi: TheoLive, private val emitte
   private fun onDistributionLoaded(event: DistributionLoadedEvent) {
     emitter.emit(Arguments.createMap().apply {
       putString(EVENT_PROP_TYPE, "distributionloaded")
-      putString(EVENT_PROP_DISTRIBUTION, event.getDistribution())
+      putMap(EVENT_PROP_DISTRIBUTION, Arguments.createMap().apply {
+        putString(EVENT_PROP_ID, event.getDistribution().id)
+        putString(EVENT_PROP_NAME, event.getDistribution().name)
+      })
     })
   }
 

--- a/e2e/android/gradle.properties
+++ b/e2e/android/gradle.properties
@@ -41,7 +41,7 @@ newArchEnabled=true
 hermesEnabled=true
 
 # Version of the THEOplayer SDK, if not specified, the latest available version within bounds is set.
-#THEOplayer_sdk=[8.1.0, 11.0.0)
+#THEOplayer_sdk=[10.10.0, 11.0.0)
 
 # Override Android sdk versions
 #THEOplayer_compileSdkVersion = 34

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -53,8 +53,8 @@
       }
     },
     "..": {
-      "version": "10.7.1",
-      "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
+      "version": "10.9.0",
+      "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@theoplayer/cmcd-connector-web": "^1.4.0",
         "buffer": "^6.0.3"
@@ -74,7 +74,7 @@
         "react": "^19.2.0",
         "react-native": "^0.83.1",
         "react-native-builder-bob": "^0.39.1",
-        "theoplayer": "^10",
+        "theoplayer": "^10.10.0",
         "typedoc": "^0.25.13",
         "typedoc-plugin-external-resolver": "^1.0.3",
         "typedoc-plugin-mdn-links": "^3.3.4",

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -46,7 +46,7 @@ hermesEnabled=true
 edgeToEdgeEnabled=false
 
 # Version of the THEOplayer SDK, if not specified, the latest available version within bounds is set.
-#THEOplayer_sdk=[10.0.1, 11.0.0)
+#THEOplayer_sdk=[10.10.0, 11.0.0)
 
 # Override Android sdk versions
 #THEOplayer_compileSdkVersion = 36

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -51,8 +51,8 @@
       }
     },
     "..": {
-      "version": "10.7.1",
-      "license": "SEE LICENSE AT https://www.theoplayer.com/terms",
+      "version": "10.9.0",
+      "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@theoplayer/cmcd-connector-web": "^1.4.0",
         "buffer": "^6.0.3"
@@ -72,7 +72,7 @@
         "react": "^19.2.0",
         "react-native": "^0.83.1",
         "react-native-builder-bob": "^0.39.1",
-        "theoplayer": "^10",
+        "theoplayer": "^10.10.0",
         "typedoc": "^0.25.13",
         "typedoc-plugin-external-resolver": "^1.0.3",
         "typedoc-plugin-mdn-links": "^3.3.4",
@@ -13325,7 +13325,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/ios/theolive/THEOplayerRCTTHEOliveEventAdapter.swift
+++ b/ios/theolive/THEOplayerRCTTHEOliveEventAdapter.swift
@@ -17,6 +17,12 @@ let PROP_ENDPOINT_PRIORITY: String = "priority"
 let PROP_ENDPOINT_CONTENT_PROTECTION: String = "contentProtection"
 let PROP_REASON_ERROR_CODE: String = "errorCode"
 let PROP_REASON_ERROR_MESSAGE: String = "errorMessage"
+let PROP_DISTRIBUTION_ID: String = "id"
+let PROP_DISTRIBUTION_NAME: String = "name"
+let PROP_DISTRIBUTION_TARGET_LATENCY: String = "targetLatency"
+let PROP_DISTRIBUTION_MAX_BITRATE: String = "maxBitrate"
+let PROP_DISTRIBUTION_ENDPOINTS: String = "endpoints"
+let PROP_DISTRIBUTION_DVR_WINDOW_SECONDS: String = "dvrWindowSeconds"
 
 class THEOplayerRCTTHEOliveEventAdapter {
 
@@ -61,6 +67,35 @@ class THEOplayerRCTTHEOliveEventAdapter {
             PROP_REASON_ERROR_MESSAGE: reason.message
         ]
     }
+    
+    class func fromDistribution(distribution: (any THEOplayerTHEOliveIntegration.DistributionAPI)?) -> [String:Any] {
+        guard let distribution = distribution else {
+            return [:]
+        }
+        
+        var distributionData: [String:Any] = [:]
+        distributionData[PROP_DISTRIBUTION_ID] = distribution.id
+        distributionData[PROP_DISTRIBUTION_NAME] = distribution.name
+        
+        if let targetLatency = distribution.targetLatency {
+            distributionData[PROP_DISTRIBUTION_TARGET_LATENCY] = targetLatency
+        }
+        if let maxBitrate = distribution.maxBitrate {
+            distributionData[PROP_DISTRIBUTION_MAX_BITRATE] = maxBitrate
+        }
+        if let dvrWindowSeconds = distribution.dvrWindowSeconds {
+            distributionData[PROP_DISTRIBUTION_DVR_WINDOW_SECONDS] = dvrWindowSeconds
+        }
+        var endpointsData: [[String:Any]] = []
+        for endpoint in distribution.endpoints {
+            endpointsData.append(THEOplayerRCTTHEOliveEventAdapter.fromEndpoint(endpoint: endpoint))
+        }
+        distributionData[PROP_DISTRIBUTION_ENDPOINTS] = endpointsData
+        
+        return distributionData
+    }
+    
+    
 #endif
     
 }

--- a/ios/theolive/THEOplayerRCTTHEOliveEventAdapter.swift
+++ b/ios/theolive/THEOplayerRCTTHEOliveEventAdapter.swift
@@ -19,10 +19,6 @@ let PROP_REASON_ERROR_CODE: String = "errorCode"
 let PROP_REASON_ERROR_MESSAGE: String = "errorMessage"
 let PROP_DISTRIBUTION_ID: String = "id"
 let PROP_DISTRIBUTION_NAME: String = "name"
-let PROP_DISTRIBUTION_TARGET_LATENCY: String = "targetLatency"
-let PROP_DISTRIBUTION_MAX_BITRATE: String = "maxBitrate"
-let PROP_DISTRIBUTION_ENDPOINTS: String = "endpoints"
-let PROP_DISTRIBUTION_DVR_WINDOW_SECONDS: String = "dvrWindowSeconds"
 
 class THEOplayerRCTTHEOliveEventAdapter {
 
@@ -76,22 +72,7 @@ class THEOplayerRCTTHEOliveEventAdapter {
         var distributionData: [String:Any] = [:]
         distributionData[PROP_DISTRIBUTION_ID] = distribution.id
         distributionData[PROP_DISTRIBUTION_NAME] = distribution.name
-        
-        if let targetLatency = distribution.targetLatency {
-            distributionData[PROP_DISTRIBUTION_TARGET_LATENCY] = targetLatency
-        }
-        if let maxBitrate = distribution.maxBitrate {
-            distributionData[PROP_DISTRIBUTION_MAX_BITRATE] = maxBitrate
-        }
-        if let dvrWindowSeconds = distribution.dvrWindowSeconds {
-            distributionData[PROP_DISTRIBUTION_DVR_WINDOW_SECONDS] = dvrWindowSeconds
-        }
-        var endpointsData: [[String:Any]] = []
-        for endpoint in distribution.endpoints {
-            endpointsData.append(THEOplayerRCTTHEOliveEventAdapter.fromEndpoint(endpoint: endpoint))
-        }
-        distributionData[PROP_DISTRIBUTION_ENDPOINTS] = endpointsData
-        
+
         return distributionData
     }
     

--- a/ios/theolive/THEOplayerRCTTHEOliveEventHandler.swift
+++ b/ios/theolive/THEOplayerRCTTHEOliveEventHandler.swift
@@ -73,7 +73,7 @@ class THEOplayerRCTTHEOliveEventHandler {
             if let forwardedTHEOliveEvent = self?.onNativeTHEOliveEvent {
                 forwardedTHEOliveEvent([
                     THEOLIVE_EVENT_PROP_TYPE: EVENT_TYPE_DISTRIBUTION_LOADED,
-                    THEOLIVE_EVENT_PROP_DISTRIBUTION: event.distribution
+                    THEOLIVE_EVENT_PROP_DISTRIBUTION: THEOplayerRCTTHEOliveEventAdapter.fromDistribution(distribution: event.distribution)
                 ])
             }
         }

--- a/ios/theolive/THEOplayerRCTTHEOliveEventHandler.swift
+++ b/ios/theolive/THEOplayerRCTTHEOliveEventHandler.swift
@@ -8,12 +8,14 @@ import THEOplayerTHEOliveIntegration
 #endif
 
 let EVENT_TYPE_DISTRIBUTION_LOAD_START: String = "distributionloadstart"
+let EVENT_TYPE_DISTRIBUTION_LOADED: String = "distributionloaded"
 let EVENT_TYPE_DISTRIBUTION_OFFLINE: String = "distributionoffline"
 let EVENT_TYPE_ENDPOINT_LOADED: String = "endpointloaded"
 let EVENT_TYPE_INTENT_TO_FALLBACK: String = "intenttofallback"
 
 let THEOLIVE_EVENT_PROP_TYPE: String = "type"
 let THEOLIVE_EVENT_PROP_DISTRIBUTION_ID: String = "distributionId"
+let THEOLIVE_EVENT_PROP_DISTRIBUTION: String = "distribution"
 let THEOLIVE_EVENT_PROP_ENDPOINT: String = "endpoint"
 let THEOLIVE_EVENT_PROP_REASON: String = "reason"
 
@@ -26,6 +28,7 @@ class THEOplayerRCTTHEOliveEventHandler {
 
     // MARK: THEOlive Listeners
     private var distributionLoadStartListener: EventListener?
+    private var distributionLoadedListener: EventListener?
     private var distributionOfflineListener: EventListener?
     private var endPointLoadedListener: EventListener?
     private var intentToFallbackListener: EventListener?
@@ -62,8 +65,21 @@ class THEOplayerRCTTHEOliveEventHandler {
             }
         }
         if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] DistributionLoadStart listener attached to THEOplayer.theolive") }
-        
-        
+
+
+        // DISTRIBUTION_LOADED
+        self.distributionLoadedListener = player.theoLive?.addEventListener(type: THEOliveEventTypes.DISTRIBUTION_LOADED) { [weak self] event in
+            if DEBUG_THEOPLAYER_EVENTS { PrintUtils.printLog(logText: "[NATIVE] Received DistributionLoaded event from THEOlive") }
+            if let forwardedTHEOliveEvent = self?.onNativeTHEOliveEvent {
+                forwardedTHEOliveEvent([
+                    THEOLIVE_EVENT_PROP_TYPE: EVENT_TYPE_DISTRIBUTION_LOADED,
+                    THEOLIVE_EVENT_PROP_DISTRIBUTION: event.distribution
+                ])
+            }
+        }
+        if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] DistributionOffline listener attached to THEOplayer.theolive") }
+
+
         // DISTRIBUTION_OFFLINE
         self.distributionOfflineListener = player.theoLive?.addEventListener(type: THEOliveEventTypes.DISTRIBUTION_OFFLINE) { [weak self] event in
             if DEBUG_THEOPLAYER_EVENTS { PrintUtils.printLog(logText: "[NATIVE] Received DistributionOffline event from THEOlive") }
@@ -116,7 +132,16 @@ class THEOplayerRCTTHEOliveEventHandler {
             )
             if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] DistributionLoadStart listener detached from THEOplayer.theolive") }
         }
-        
+
+        // DISTRIBUTION_LOADED
+        if let distributionLoadedListener = self.distributionLoadedListener {
+            player.theoLive?.removeEventListener(
+                type: THEOliveEventTypes.DISTRIBUTION_LOADED,
+                listener: distributionLoadedListener
+            )
+            if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] DistributionLoaded listener detached from THEOplayer.theolive") }
+        }
+
         // DISTRIBUTION_OFFLINE
         if let distributionOfflineListener = self.distributionOfflineListener {
             player.theoLive?.removeEventListener(

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react": "^19.2.0",
         "react-native": "^0.83.1",
         "react-native-builder-bob": "^0.39.1",
-        "theoplayer": "^10",
+        "theoplayer": "^10.10.0",
         "typedoc": "^0.25.13",
         "typedoc-plugin-external-resolver": "^1.0.3",
         "typedoc-plugin-mdn-links": "^3.3.4",
@@ -10857,9 +10857,9 @@
       "dev": true
     },
     "node_modules/theoplayer": {
-      "version": "10.6.1",
-      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-10.6.1.tgz",
-      "integrity": "sha512-mz3LpcChF0/pUWJwzJtMwKWyuqmv85Ao8eAFVmYFI0K+krjC+yAm28suFa7E6BITZfNTtwlDTY+ZPRDcxd6+ng==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/theoplayer/-/theoplayer-10.10.0.tgz",
+      "integrity": "sha512-24UKdnryzQHl8ch+E3YLJv4swZpydtjNZuh+mA57xBosQsirIxMKuuU0tE6ZjRu21ULgreu2KFwy3Qg9n0hMgg==",
       "license": "SEE LICENSE AT https://www.theoplayer.com/terms"
     },
     "node_modules/throat": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "react": "^19.2.0",
     "react-native": "^0.83.1",
     "react-native-builder-bob": "^0.39.1",
-    "theoplayer": "^10",
+    "theoplayer": "^10.10.0",
     "typedoc": "^0.25.13",
     "typedoc-plugin-external-resolver": "^1.0.3",
     "typedoc-plugin-mdn-links": "^3.3.4",

--- a/react-native-theoplayer.podspec
+++ b/react-native-theoplayer.podspec
@@ -43,37 +43,37 @@ Pod::Spec.new do |s|
 
   # THEOplayer Dependency
   puts "Adding THEOplayerSDK-core"
-  s.dependency "THEOplayerSDK-core", "~> 10.7"
+  s.dependency "THEOplayerSDK-core", "~> 10.10"
 
   # THEOlive Dependency
   puts "Adding THEOplayer-Integration-THEOlive"
-  s.dependency "THEOplayer-Integration-THEOlive", "~> 10.7"
+  s.dependency "THEOplayer-Integration-THEOlive", "~> 10.10"
 
   # Feature based integration dependencies
   if theofeatures.include?("GOOGLE_IMA")
 	puts "Adding THEOplayer-Integration-GoogleIMA"
-    s.dependency "THEOplayer-Integration-GoogleIMA", "~> 10.7"
+    s.dependency "THEOplayer-Integration-GoogleIMA", "~> 10.10"
   end
 
   if theofeatures.include?("CHROMECAST")
 	puts "Adding THEOplayer-Integration-GoogleCast"
-    s.ios.dependency "THEOplayer-Integration-GoogleCast", "~> 10.7"
+    s.ios.dependency "THEOplayer-Integration-GoogleCast", "~> 10.10"
   end
 
   if theofeatures.include?("THEO_ADS")
 	puts "Adding THEOplayer-Integration-THEOads"
-    s.dependency "THEOplayer-Integration-THEOads", "~> 10.7"
+    s.dependency "THEOplayer-Integration-THEOads", "~> 10.10"
   end
 
   if theofeatures.include?("MILLICAST")
   puts "Adding THEOplayer-Integration-Millicast"
-    s.dependency "THEOplayer-Integration-Millicast", "~> 10.7"
+    s.dependency "THEOplayer-Integration-Millicast", "~> 10.10"
   end
 
   # Feature based connector dependencies
   if theofeatures.include?("SIDELOADED_TEXTTRACKS")
 	puts "Adding THEOplayer-Connector-SideloadedSubtitle"
-    s.dependency "THEOplayer-Connector-SideloadedSubtitle", "~> 10.7"
+    s.dependency "THEOplayer-Connector-SideloadedSubtitle", "~> 10.10"
   end
 
 end

--- a/src/api/event/TheoLiveEvent.ts
+++ b/src/api/event/TheoLiveEvent.ts
@@ -1,4 +1,5 @@
 import { Event, PlayerError, PlayerEventType, TheoLiveEndpoint } from 'react-native-theoplayer';
+import { TheoLiveDistribution } from '../theolive/TheoLiveDistribution';
 
 /**
  * The THEOlive event dispatched by the {@link TheoLiveAPI THEOlive API}.
@@ -24,6 +25,18 @@ export interface TheoLiveDistributionEvent extends TheoLiveEvent {
    * The distribution identifier
    */
   distributionId: string;
+}
+
+/**
+ * Dispatched when a THEOlive distribution has been successfully loaded.
+ *
+ * @public
+ */
+export interface TheoLiveDistributionLoadedEvent extends TheoLiveEvent {
+  /**
+   * The distribution info.
+   */
+  distribution?: TheoLiveDistribution;
 }
 
 /**
@@ -66,6 +79,13 @@ export enum TheoLiveEventType {
    * @public
    */
   DISTRIBUTION_LOAD_START = 'distributionloadstart',
+
+  /**
+   * Dispatched when a THEOlive distribution has been successfully loaded.
+   *
+   * @public
+   */
+  DISTRIBUTION_LOADED = 'distributionloaded',
 
   /**
    * Dispatched when loading a THEOlive distribution that cannot be played, for example because the publication is

--- a/src/api/theolive/TheoLiveDistribution.ts
+++ b/src/api/theolive/TheoLiveDistribution.ts
@@ -1,0 +1,16 @@
+import { TheoLiveEndpoint } from 'react-native-theoplayer';
+
+/**
+ * A THEOlive distribution.
+ *
+ * @category THEOlive
+ * @public
+ */
+export interface TheoLiveDistribution {
+  id: string;
+  name: string;
+  targetLatency?: number;
+  maxBitrate?: number;
+  endpoints: TheoLiveEndpoint[];
+  dvrWindowSeconds?: number;
+}

--- a/src/api/theolive/TheoLiveDistribution.ts
+++ b/src/api/theolive/TheoLiveDistribution.ts
@@ -1,5 +1,3 @@
-import { TheoLiveEndpoint } from 'react-native-theoplayer';
-
 /**
  * A THEOlive distribution.
  *
@@ -9,8 +7,4 @@ import { TheoLiveEndpoint } from 'react-native-theoplayer';
 export interface TheoLiveDistribution {
   id: string;
   name: string;
-  targetLatency?: number;
-  maxBitrate?: number;
-  endpoints: TheoLiveEndpoint[];
-  dvrWindowSeconds?: number;
 }

--- a/src/api/theolive/barrel.ts
+++ b/src/api/theolive/barrel.ts
@@ -1,4 +1,5 @@
 export * from './TheoLiveAPI';
 export * from './TheoLiveConfiguration';
 export * from './TheoLiveEndpoint';
+export * from './TheoLiveDistribution';
 export * from './TheoLiveSource';

--- a/src/internal/adapter/WebEventForwarder.ts
+++ b/src/internal/adapter/WebEventForwarder.ts
@@ -67,6 +67,7 @@ import {
   DefaultTheoAdsErrorEvent,
   DefaultTheoAdsEvent,
   DefaultTheoLiveDistributionEvent,
+  DefaultTheoLiveDistributionLoadedEvent,
   DefaultTheoLiveEndpointLoadedEvent,
   DefaultTheoLiveEvent,
   DefaultTheoLiveIntentToFallbackEvent,
@@ -387,6 +388,9 @@ export class WebEventForwarder {
     if (event.type === TheoLiveEventType.DISTRIBUTION_LOAD_START || event.type === TheoLiveEventType.DISTRIBUTION_OFFLINE) {
       const { distributionId } = event;
       this._facade.dispatchEvent(new DefaultTheoLiveDistributionEvent(event.type as TheoLiveEventType, distributionId));
+    } else if (event.type === TheoLiveEventType.DISTRIBUTION_LOADED) {
+      const { distribution } = event;
+      this._facade.dispatchEvent(new DefaultTheoLiveDistributionLoadedEvent(event.type as TheoLiveEventType, distribution));
     } else if (event.type === TheoLiveEventType.ENDPOINT_LOADED) {
       const { endpoint } = event;
       this._facade.dispatchEvent(new DefaultTheoLiveEndpointLoadedEvent(event.type as TheoLiveEventType, endpoint));
@@ -477,6 +481,7 @@ type ForwardedTheoAdsEvent = NativeTheoAdsEventsMap[(typeof FORWARDED_THEOADS_EV
 
 const FORWARDED_THEOLIVE_EVENTS = [
   TheoLiveEventType.DISTRIBUTION_LOAD_START,
+  TheoLiveEventType.DISTRIBUTION_LOADED,
   TheoLiveEventType.DISTRIBUTION_OFFLINE,
   TheoLiveEventType.ENDPOINT_LOADED,
   TheoLiveEventType.INTENT_TO_FALLBACK,

--- a/src/internal/adapter/WebEventForwarder.ts
+++ b/src/internal/adapter/WebEventForwarder.ts
@@ -385,25 +385,28 @@ export class WebEventForwarder {
   };
 
   private readonly onTheoLiveEvent = (event: ForwardedTheoLiveEvent) => {
-    if (event.type === TheoLiveEventType.DISTRIBUTION_LOAD_START || event.type === TheoLiveEventType.DISTRIBUTION_OFFLINE) {
-      const { distributionId } = event;
-      this._facade.dispatchEvent(new DefaultTheoLiveDistributionEvent(event.type as TheoLiveEventType, distributionId));
-    } else if (event.type === TheoLiveEventType.DISTRIBUTION_LOADED) {
-      const { distribution } = event;
-      this._facade.dispatchEvent(new DefaultTheoLiveDistributionLoadedEvent(event.type as TheoLiveEventType, distribution));
-    } else if (event.type === TheoLiveEventType.ENDPOINT_LOADED) {
-      const { endpoint } = event;
-      this._facade.dispatchEvent(new DefaultTheoLiveEndpointLoadedEvent(event.type as TheoLiveEventType, endpoint));
-    } else if (event.type === TheoLiveEventType.INTENT_TO_FALLBACK) {
-      const { reason } = event;
-      this._facade.dispatchEvent(
-        new DefaultTheoLiveIntentToFallbackEvent(event.type as TheoLiveEventType, {
-          errorCode: reason?.code?.toString() ?? '',
-          errorMessage: reason?.message ?? '',
-        }),
-      );
-    } else {
-      this._facade.dispatchEvent(new DefaultTheoLiveEvent((event as NativeEvent).type as TheoLiveEventType));
+    switch (event.type) {
+      case TheoLiveEventType.DISTRIBUTION_LOAD_START:
+      case TheoLiveEventType.DISTRIBUTION_OFFLINE:
+        this._facade.dispatchEvent(new DefaultTheoLiveDistributionEvent(event.type as TheoLiveEventType, event.distributionId));
+        break;
+      case TheoLiveEventType.DISTRIBUTION_LOADED:
+        this._facade.dispatchEvent(new DefaultTheoLiveDistributionLoadedEvent(event.type as TheoLiveEventType, event.distribution));
+        break;
+      case TheoLiveEventType.ENDPOINT_LOADED:
+        this._facade.dispatchEvent(new DefaultTheoLiveEndpointLoadedEvent(event.type as TheoLiveEventType, event.endpoint));
+        break;
+      case TheoLiveEventType.INTENT_TO_FALLBACK:
+        this._facade.dispatchEvent(
+          new DefaultTheoLiveIntentToFallbackEvent(event.type as TheoLiveEventType, {
+            errorCode: event.reason?.code?.toString() ?? '',
+            errorMessage: event.reason?.message ?? '',
+          }),
+        );
+        break;
+      default:
+        this._facade.dispatchEvent(new DefaultTheoLiveEvent(event.type as TheoLiveEventType));
+        return;
     }
   };
 

--- a/src/internal/adapter/event/PlayerEvents.ts
+++ b/src/internal/adapter/event/PlayerEvents.ts
@@ -10,6 +10,7 @@ import {
   ChromecastChangeEvent,
   ChromecastError,
   ChromecastErrorEvent,
+  DimensionChangeEvent,
   DurationChangeEvent,
   ErrorEvent,
   Interstitial,
@@ -37,22 +38,23 @@ import {
   TextTrackEvent,
   TextTrackEventType,
   TextTrackListEvent,
-  TheoAdsEvent,
   TheoAdsErrorEvent,
+  TheoAdsEvent,
   TheoAdsEventType,
-  TheoLiveEvent,
   TheoLiveDistributionEvent,
+  TheoLiveDistributionLoadedEvent,
+  TheoLiveEndpoint,
+  TheoLiveEndpointLoadedEvent,
+  TheoLiveEvent,
   TheoLiveEventType,
+  TheoLiveIntentToFallbackEvent,
   TimeRange,
   TimeUpdateEvent,
   TrackListEventType,
-  VolumeChangeEvent,
-  TheoLiveEndpoint,
-  TheoLiveEndpointLoadedEvent,
-  TheoLiveIntentToFallbackEvent,
-  DimensionChangeEvent,
   VideoResizeEvent,
+  VolumeChangeEvent,
 } from 'react-native-theoplayer';
+import { TheoLiveDistribution } from '../../../api/theolive/TheoLiveDistribution';
 
 export class DefaultLoadedMetadataEvent extends BaseEvent<PlayerEventType.LOADED_METADATA> implements LoadedMetadataEvent {
   constructor(
@@ -259,6 +261,15 @@ export class DefaultTheoLiveDistributionEvent extends BaseEvent<PlayerEventType.
   constructor(
     public subType: TheoLiveEventType,
     public distributionId: string,
+  ) {
+    super(PlayerEventType.THEOLIVE_EVENT);
+  }
+}
+
+export class DefaultTheoLiveDistributionLoadedEvent extends BaseEvent<PlayerEventType.THEOLIVE_EVENT> implements TheoLiveDistributionLoadedEvent {
+  constructor(
+    public subType: TheoLiveEventType,
+    public distribution?: TheoLiveDistribution,
   ) {
     super(PlayerEventType.THEOLIVE_EVENT);
   }

--- a/src/internal/adapter/event/native/NativeTheoLiveEvent.ts
+++ b/src/internal/adapter/event/native/NativeTheoLiveEvent.ts
@@ -21,7 +21,7 @@ export interface NativeTheoLiveEvent {
   distributionId: string | undefined;
 
   /**
-   * Description of the THEOlive distribution.
+   * Description of the THEOlive distribution for DISTRIBUTION_LOADED events.
    */
   distribution: TheoLiveDistribution | undefined;
 

--- a/src/internal/adapter/event/native/NativeTheoLiveEvent.ts
+++ b/src/internal/adapter/event/native/NativeTheoLiveEvent.ts
@@ -2,10 +2,12 @@ import { PlayerError, TheoLiveEndpoint, TheoLiveEvent, TheoLiveEventType } from 
 import { NativeSyntheticEvent } from 'react-native';
 import {
   DefaultTheoLiveDistributionEvent,
+  DefaultTheoLiveDistributionLoadedEvent,
   DefaultTheoLiveEndpointLoadedEvent,
-  DefaultTheoLiveIntentToFallbackEvent,
   DefaultTheoLiveEvent,
+  DefaultTheoLiveIntentToFallbackEvent,
 } from '../PlayerEvents';
+import { TheoLiveDistribution } from '../../../../api/theolive/TheoLiveDistribution';
 
 export interface NativeTheoLiveEvent {
   /**
@@ -17,6 +19,11 @@ export interface NativeTheoLiveEvent {
    * The distribution identifier for DISTRIBUTION_LOAD_START or DISTRIBUTION_OFFLINE events
    */
   distributionId: string | undefined;
+
+  /**
+   * Description of the THEOlive distribution.
+   */
+  distribution: TheoLiveDistribution | undefined;
 
   /**
    * Description of the THEOlive endpoint.
@@ -34,6 +41,8 @@ export function fromNativeTheoLiveEvent(event: NativeSyntheticEvent<NativeTheoLi
   switch (event.type) {
     case TheoLiveEventType.DISTRIBUTION_LOAD_START:
       return new DefaultTheoLiveDistributionEvent(TheoLiveEventType.DISTRIBUTION_LOAD_START, nativeEvent.distributionId ?? '');
+    case TheoLiveEventType.DISTRIBUTION_LOADED:
+      return new DefaultTheoLiveDistributionLoadedEvent(TheoLiveEventType.DISTRIBUTION_LOADED, nativeEvent.distribution ?? undefined);
     case TheoLiveEventType.DISTRIBUTION_OFFLINE:
       return new DefaultTheoLiveDistributionEvent(TheoLiveEventType.DISTRIBUTION_OFFLINE, nativeEvent.distributionId ?? '');
     case TheoLiveEventType.ENDPOINT_LOADED:


### PR DESCRIPTION
Bridges the `distributionloaded` event to react native. It still needs to land in the player itself so this has to wait for those changes first.