### PR TITLE
drop react-native-google-cast fork from example on iOS

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -24,7 +24,7 @@ target 'ReactNativeTHEOplayer' do
     :path => config[:reactNativePath],
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )
-  pod 'react-native-google-cast', :git => 'https://github.com/Danesz/react-native-google-cast.git', branch: 'feature/guestmode_apple_silicon'
+  pod 'react-native-google-cast', path: '../node_modules/react-native-google-cast/' #link react-native-google-cast only for iOS
 end
 
 target 'ReactNativeTHEOplayer-tvOS' do

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -13,6 +13,7 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-native": "npm:react-native-tvos@^0.84.1-0",
+        "react-native-google-cast": "^4.9.1",
         "react-native-safe-area-context": "^5.5.2",
         "react-native-status-bar-height": "^2.6.0",
         "react-native-svg": "^15.12.1",
@@ -11304,7 +11305,6 @@
       "resolved": "https://registry.npmjs.org/react-native-google-cast/-/react-native-google-cast-4.9.1.tgz",
       "integrity": "sha512-/HvIKAaWHtG6aTNCxrNrqA2ftWGkfH0M/2iN+28pdGUXpKmueb33mgL1m8D4zzwEODQMcmpfoCsym1IwDvugBQ==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -13317,7 +13317,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/example/package.json
+++ b/example/package.json
@@ -20,6 +20,7 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-native": "npm:react-native-tvos@^0.84.1-0",
+    "react-native-google-cast": "^4.9.1",
     "react-native-safe-area-context": "^5.5.2",
     "react-native-status-bar-height": "^2.6.0",
     "react-native-svg": "^15.12.1",

--- a/example/react-native.config.js
+++ b/example/react-native.config.js
@@ -2,11 +2,9 @@ module.exports = {
   dependencies: {
     'react-native-google-cast': {
       platforms: {
-        // iOS needs to disable autolinking for this package and add an explicit dependency to
-        // https://github.com/Danesz/react-native-google-cast.git', branch: 'feature/guestmode_apple_silicon'
-        // in Podfile.
+        // we need to disable auto-linking for this and add an explicit dependency to the ios target in the podfile,
+        // because tvOS does not support react-native-google-cast
         ios: null,
-
         // Android should auto-link its peer dependency from @theoplayer/react-native-ui
         android: {},
       },


### PR DESCRIPTION
Requires an iOS THEOplayer-GoogleCast-Integration with 'google-cast-sdk' dependency.