### PR TITLE
Add `TextTrack.captionChannel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added support for player SDK v11. More info on the [migration documentation](./doc/migrating-to-react-native-theoplayer-11.md) page.
 - Enabled core library desugaring for Android to support version 3.39.0 of the Google IMA SDK.
+- Added `TextTrack.captionChannel` to retrieve the CEA-608 channel and/or CEA-708 service numbers of closed caption text tracks.
 
 ### Changed
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -92,6 +92,9 @@ android {
             minifyEnabled false
         }
     }
+    buildFeatures {
+        buildConfig true
+    }
     lint {
         disable 'GradleCompatible'
     }

--- a/android/src/main/java/com/theoplayer/track/TrackListAdapter.kt
+++ b/android/src/main/java/com/theoplayer/track/TrackListAdapter.kt
@@ -26,6 +26,7 @@ private const val PROP_NAME = "name"
 private const val PROP_ENABLED = "enabled"
 private const val PROP_SRC = "src"
 private const val PROP_FORCED = "forced"
+private const val PROP_CAPTION_CHANNEL = "captionChannel"
 private const val PROP_AUDIO_SAMPLING_RATE = "audioSamplingRate"
 private const val PROP_BANDWIDTH = "bandwidth"
 private const val PROP_QUALITIES = "qualities"
@@ -68,6 +69,9 @@ object TrackListAdapter {
     // THEOplayer v3.5+
     textTrackPayload.putString(PROP_SRC, textTrack.source)
     textTrackPayload.putBoolean(PROP_FORCED, textTrack.isForced)
+
+    // THEOplayer v10.13+
+    textTrack.captionChannel?.let { textTrackPayload.putInt(PROP_CAPTION_CHANNEL, it) }
 
     // Optionally pass cue list.
     val cueList = textTrack.cues

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -87,7 +87,7 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
-        "theoplayer": "^9.12.0 || ^10 || ^11"
+        "theoplayer": "^11"
       },
       "peerDependenciesMeta": {
         "theoplayer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*",
-        "theoplayer": "^9.12.0 || ^10 || ^11"
+        "theoplayer": "^11"
       },
       "peerDependenciesMeta": {
         "theoplayer": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
   "peerDependencies": {
     "react": "*",
     "react-native": "*",
-    "theoplayer": "^9.12.0 || ^10 || ^11"
+    "theoplayer": "^11"
   },
   "peerDependenciesMeta": {
     "theoplayer": {

--- a/src/api/track/TextTrack.ts
+++ b/src/api/track/TextTrack.ts
@@ -153,11 +153,12 @@ export interface TextTrack extends Track {
   /**
    * The closed caption service number of the text track.
    *
+   * @platform web,android
+   *
    * @remarks
    * <br/> - For CEA-608 caption tracks, this holds the channel number.
    * <br/> - For CEA-708 caption tracks, this holds the service number.
    * <br/> - Otherwise, this is `undefined`.
-   * <br/> - Not yet supported on iOS.
    */
   readonly captionChannel?: number;
 }

--- a/src/api/track/TextTrack.ts
+++ b/src/api/track/TextTrack.ts
@@ -149,6 +149,17 @@ export interface TextTrack extends Track {
    * <br/> - For HLS: the corresponding #EXT-X-MEDIA tag contains the attributes TYPE=SUBTITLES and FORCED=YES (not supported yet)
    */
   readonly forced: boolean;
+
+  /**
+   * The closed caption service number of the text track.
+   *
+   * @remarks
+   * <br/> - For CEA-608 caption tracks, this holds the channel number.
+   * <br/> - For CEA-708 caption tracks, this holds the service number.
+   * <br/> - Otherwise, this is `undefined`.
+   * <br/> - Not yet supported on iOS.
+   */
+  readonly captionChannel?: number;
 }
 
 /**

--- a/src/internal/adapter/web/TrackUtils.ts
+++ b/src/internal/adapter/web/TrackUtils.ts
@@ -41,7 +41,7 @@ export function fromNativeTextTrackList(tracks: NativeTextTrackList): TextTrack[
 }
 
 export function fromNativeTextTrack(track: NativeTextTrack): TextTrack {
-  const { id, uid, kind, label, language, mode, type, src, forced } = track;
+  const { id, uid, kind, label, language, mode, type, src, forced, captionChannel } = track;
 
   return {
     id,
@@ -53,6 +53,7 @@ export function fromNativeTextTrack(track: NativeTextTrack): TextTrack {
     type,
     src,
     forced,
+    captionChannel,
     cues: track.cues ? track.cues.map((cue) => fromNativeCue(cue)) : [],
   } as TextTrack;
 }


### PR DESCRIPTION
`TextTrack.captionChannel` was added in Android SDK 10.13.0 and Web SDK 10.14.0, so this also bump the minimum SDK versions to those versions.