### PR TITLE
Bridge useSystemCaptionStyle on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added `useSystemCaptionStyle` flag to `PlayerConfiguration` on Android. When set to `true`, the player will apply the caption styles as configured in the system settings.
+
 ## [11.0.0] - 26-04-16
 
 ### Added

--- a/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
+++ b/android/src/main/java/com/theoplayer/PlayerConfigAdapter.kt
@@ -44,6 +44,8 @@ private const val PROP_THEOLIVE_ANALYTICS_DISABLED = "analyticsDisabled"
 private const val PROP_THEOLIVE_DISCOVERY_URL = "discoveryUrl"
 private const val PROP_MULTIMEDIA_TUNNELING_ENABLED = "tunnelingEnabled"
 private const val PROP_DEBUG_LOGS_ENABLED = "debugLogsEnabled"
+private const val PROP_SYSTEM_CAPTION_STYLE = "useSystemCaptionStyle"
+
 
 class PlayerConfigAdapter(private val configProps: ReadableMap?) {
 
@@ -82,6 +84,9 @@ class PlayerConfigAdapter(private val configProps: ReadableMap?) {
         autoIntegrations(false)
         if (hasKey(PROP_MULTIMEDIA_TUNNELING_ENABLED)) {
           tunnelingEnabled(getBoolean(PROP_MULTIMEDIA_TUNNELING_ENABLED))
+        }
+        if (hasKey(PROP_SYSTEM_CAPTION_STYLE)) {
+          useSystemCaptionStyle(getBoolean(PROP_SYSTEM_CAPTION_STYLE))
         }
       }
     }.build()

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -86,6 +86,8 @@ const playerConfig: PlayerConfiguration = {
   ads: {
     theoads: true,
   },
+  debugLogsEnabled: false, // Android only.
+  useSystemCaptionStyle: false, // Android only.
 };
 
 /**

--- a/src/api/config/PlayerConfiguration.ts
+++ b/src/api/config/PlayerConfiguration.ts
@@ -130,6 +130,18 @@ export interface PlayerConfiguration {
    * <br/> - When set to true, all debug log tags from the native Android SDK will be enabled.
    */
   debugLogsEnabled?: boolean;
+
+  /**
+   * Sets whether captions should automatically apply a system-defined style.
+   *
+   * @defaultValue false
+   *
+   * @platform android
+   *
+   * @remarks
+   * <br/> - Any user-defined overrides are still respected.
+   */
+  useSystemCaptionStyle?: boolean;
 }
 
 /**


### PR DESCRIPTION
This PR bridges the new [useSystemCaptionStyle](https://optiview.dolby.com/docs/theoplayer/v11/api-reference/android/com/theoplayer/android/api/THEOplayerConfig.Builder.html#useSystemCaptionStyle(boolean)) flag on Android.