### PR TITLE
Feature/custom ad integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added support for `CustomAdIntegrationKind`, allowing custom ad integrations on top of the player API.
+
 ## [11.1.0] - 26-05-27
 
 ### Added

--- a/android/src/main/java/com/theoplayer/ads/AdsModule.kt
+++ b/android/src/main/java/com/theoplayer/ads/AdsModule.kt
@@ -45,7 +45,7 @@ class AdsModule(context: ReactApplicationContext) : ReactContextBaseJavaModule(c
   fun schedule(tag: Int, ad: ReadableMap) {
     viewResolver.resolveViewByTag(tag) { view: ReactTHEOplayerView? ->
       try {
-        view?.adsApi?.schedule(sourceHelper.parseAdFromJS(ad))
+        view?.adsApi?.schedule(sourceHelper.parseAdDescriptionFromJS(ad))
       } catch (exception: THEOplayerException) {
         Log.e(NAME, exception.message ?: ERR_SCHEDULE_AD)
       }

--- a/android/src/main/java/com/theoplayer/source/SourceAdapter.kt
+++ b/android/src/main/java/com/theoplayer/source/SourceAdapter.kt
@@ -23,6 +23,7 @@ import com.theoplayer.android.api.ads.theoads.TheoAdsLayoutOverride
 import com.theoplayer.android.api.cmcd.CMCDTransmissionMode
 import com.theoplayer.android.api.error.ErrorCode
 import com.theoplayer.android.api.source.AdIntegration
+import com.theoplayer.android.api.source.addescription.CustomAdDescriptionRegistry
 import com.theoplayer.android.api.source.dash.DashPlaybackConfiguration
 import com.theoplayer.android.api.theolive.PlayoutDelay
 import com.theoplayer.android.api.theolive.TheoLiveSource
@@ -82,8 +83,8 @@ private const val PROP_PLAYOUT_DELAY_MAX: String = "maximum"
 
 private const val ERROR_IMA_NOT_ENABLED = "Google IMA support not enabled."
 private const val ERROR_THEOADS_NOT_ENABLED = "THEOads support not enabled."
-private const val ERROR_UNSUPPORTED_CSAI_INTEGRATION = "Unsupported CSAI integration"
-private const val ERROR_MISSING_CSAI_INTEGRATION = "Missing CSAI integration"
+private const val ERROR_UNSUPPORTED_AD_INTEGRATION = "Unsupported Ad integration"
+private const val ERROR_MISSING_AD_INTEGRATION = "Missing Ad integration"
 
 private const val PROP_SSAI_INTEGRATION_GOOGLE_DAI = "google-dai"
 
@@ -151,7 +152,9 @@ class SourceAdapter {
           val jsonAdDescription = jsonAds[i] as JSONObject
 
           // Currently only ima-ads are supported.
-          ads.add(parseAdFromJS(jsonAdDescription))
+          parseAdDescriptionFromJS(jsonAdDescription)?.let {
+            ads.add(it)
+          }
         }
       }
 
@@ -278,16 +281,6 @@ class SourceAdapter {
     }
   }
 
-  @Throws(THEOplayerException::class)
-  fun parseAdFromJS(map: ReadableMap): AdDescription? {
-    return try {
-      parseAdFromJS(JSONObject(gson.toJson(map.toHashMap())))
-    } catch (e: JSONException) {
-      e.printStackTrace()
-      null
-    }
-  }
-
   private fun parseSourceType(jsonTypedSource: JSONObject): SourceType? {
     val type = jsonTypedSource.optString(PROP_TYPE)
     if (type.isNotEmpty()) {
@@ -308,30 +301,39 @@ class SourceAdapter {
     return null
   }
 
+  @Throws(THEOplayerException::class)
+  fun parseAdDescriptionFromJS(map: ReadableMap): AdDescription? {
+    return try {
+      parseAdDescriptionFromJS(JSONObject(gson.toJson(map.toHashMap())))
+    } catch (e: JSONException) {
+      e.printStackTrace()
+      null
+    }
+  }
+
   @Throws(JSONException::class, THEOplayerException::class)
-  fun parseAdFromJS(jsonAdDescription: JSONObject): AdDescription {
+  fun parseAdDescriptionFromJS(jsonAdDescription: JSONObject): AdDescription? {
     val integrationStr = jsonAdDescription.optString(PROP_INTEGRATION)
     return if (!TextUtils.isEmpty(integrationStr)) {
       when (integrationStr) {
-        AdIntegration.GOOGLE_IMA.adIntegration -> parseImaAdFromJS(jsonAdDescription)
-        AdIntegration.THEO_ADS.adIntegration -> parseTheoAdFromJS(jsonAdDescription)
-        else -> {
-          throw THEOplayerException(
+        AdIntegration.GOOGLE_IMA.adIntegration -> parseImaAdDescriptionFromJS(jsonAdDescription)
+        AdIntegration.THEO_ADS.adIntegration -> parseTheoAdDescriptionFromJS(jsonAdDescription)
+        else ->
+          CustomAdDescriptionRegistry.deserialize(integrationStr, jsonAdDescription.toString()) ?: throw THEOplayerException(
             ErrorCode.AD_ERROR,
-            "$ERROR_UNSUPPORTED_CSAI_INTEGRATION: $integrationStr"
+            "$ERROR_UNSUPPORTED_AD_INTEGRATION: $integrationStr"
           )
-        }
       }
     } else {
       throw THEOplayerException(
         ErrorCode.AD_ERROR,
-        "$ERROR_MISSING_CSAI_INTEGRATION: $integrationStr"
+        "$ERROR_MISSING_AD_INTEGRATION: $integrationStr"
       )
     }
   }
 
   @Throws(THEOplayerException::class)
-  private fun parseImaAdFromJS(jsonAdDescription: JSONObject): GoogleImaAdDescription {
+  private fun parseImaAdDescriptionFromJS(jsonAdDescription: JSONObject): GoogleImaAdDescription {
     if (!BuildConfig.EXTENSION_GOOGLE_IMA) {
       throw THEOplayerException(ErrorCode.AD_ERROR, ERROR_IMA_NOT_ENABLED)
     }
@@ -349,7 +351,7 @@ class SourceAdapter {
   }
 
   @Throws(JSONException::class)
-  private fun parseTheoAdFromJS(jsonAdDescription: JSONObject): TheoAdDescription {
+  private fun parseTheoAdDescriptionFromJS(jsonAdDescription: JSONObject): TheoAdDescription {
     if (!BuildConfig.EXTENSION_THEOADS) {
       throw THEOplayerException(ErrorCode.AD_ERROR, ERROR_THEOADS_NOT_ENABLED)
     }
@@ -376,9 +378,9 @@ class SourceAdapter {
 
   private fun parseOverrideLayout(override: String?): TheoAdsLayoutOverride? {
     return when (override) {
-      "single", "single-if-mobile" -> return TheoAdsLayoutOverride.SINGLE
-      "l-shape" -> return TheoAdsLayoutOverride.LSHAPE
-      "double" -> return TheoAdsLayoutOverride.DOUBLE
+      "single", "single-if-mobile" -> TheoAdsLayoutOverride.SINGLE
+      "l-shape" -> TheoAdsLayoutOverride.LSHAPE
+      "double" -> TheoAdsLayoutOverride.DOUBLE
       else -> null
     }
   }
@@ -395,11 +397,11 @@ class SourceAdapter {
 
   private fun parseTextTrackKind(kind: String?): TextTrackKind? {
     return when (kind) {
-      "subtitles" -> return TextTrackKind.SUBTITLES
-      "metadata" -> return TextTrackKind.METADATA
-      "captions" -> return TextTrackKind.CAPTIONS
-      "chapters" -> return TextTrackKind.CHAPTERS
-      "descriptions" -> return TextTrackKind.DESCRIPTIONS
+      "subtitles" -> TextTrackKind.SUBTITLES
+      "metadata" -> TextTrackKind.METADATA
+      "captions" -> TextTrackKind.CAPTIONS
+      "chapters" -> TextTrackKind.CHAPTERS
+      "descriptions" -> TextTrackKind.DESCRIPTIONS
       else -> null
     }
   }

--- a/ios/ads/THEOplayerRCTSourceDescriptionBuilder+Ads.swift
+++ b/ios/ads/THEOplayerRCTSourceDescriptionBuilder+Ads.swift
@@ -6,6 +6,17 @@ import UIKit
 
 let SD_PROP_ADS: String = "ads"
 
+public class CustomAdDescription: AdDescription {
+    public let integration: THEOplayerSDK.AdIntegration? = AdIntegration.none
+    public let customIntegrationId: String
+    public let integrationData: [String: Any]
+  
+    public init(customIntegrationId: String, integrationData: [String: Any] = [:]) {
+        self.customIntegrationId = customIntegrationId
+        self.integrationData = integrationData
+    }
+}
+
 extension THEOplayerRCTSourceDescriptionBuilder {
 
     /**
@@ -58,8 +69,19 @@ extension THEOplayerRCTSourceDescriptionBuilder {
             case "theoads":
                 return THEOplayerRCTSourceDescriptionBuilder.buildSingleTHEOadsDescription(adsData)
             default:
-                if DEBUG_SOURCE_DESCRIPTION_BUILDER  { PrintUtils.printLog(logText: "[NATIVE] We currently require and only support the 'google-ima' or 'sgai' integration in the 'ads' description.") }
+                return THEOplayerRCTSourceDescriptionBuilder.buildSingleCustomAdsDescription(adsData)
             }
+        }
+        return nil
+    }
+  
+     /**
+      Creates a THEOplayer AdDescription, containing all passed properties.
+      - returns: a THEOplayer AdDescription
+     */
+    static func buildSingleCustomAdsDescription(_ adsData: [String:Any]) -> AdDescription? {
+        if let integration = adsData[SD_PROP_INTEGRATION] as? String {
+            return CustomAdDescription(customIntegrationId: integration, integrationData: adsData)
         }
         return nil
     }

--- a/ios/ads/THEOplayerRCTSourceDescriptionBuilder+Ads.swift
+++ b/ios/ads/THEOplayerRCTSourceDescriptionBuilder+Ads.swift
@@ -35,10 +35,15 @@ extension THEOplayerRCTSourceDescriptionBuilder {
                         adsDescriptions?.append(adDescription)
                     } else {
                         if DEBUG_SOURCE_DESCRIPTION_BUILDER {
-                            PrintUtils.printLog(logText: "[NATIVE] Could not create THEOplayer GoogleImaAdDescription from adsData array")
+                            PrintUtils.printLog(logText: "[NATIVE] Could not create AdDescription from adsData")
                         }
-                        return nil
                     }
+                }
+                if adsDescriptions?.isEmpty == true {
+                    if DEBUG_SOURCE_DESCRIPTION_BUILDER {
+                        PrintUtils.printLog(logText: "[NATIVE] Could not create any AdDescription from adsData array")
+                    }
+                    return nil
                 }
             }
             // case: single ads object
@@ -47,7 +52,7 @@ extension THEOplayerRCTSourceDescriptionBuilder {
                     adsDescriptions?.append(adDescription)
                 } else {
                     if DEBUG_SOURCE_DESCRIPTION_BUILDER {
-                        PrintUtils.printLog(logText: "[NATIVE] Could not create THEOplayer GoogleImaAdDescription from adsData")
+                        PrintUtils.printLog(logText: "[NATIVE] Could not create AdDescription from adsData")
                     }
                     return nil
                 }

--- a/src/api/ads/Ad.ts
+++ b/src/api/ads/Ad.ts
@@ -1,5 +1,6 @@
 import type { AdBreak } from './AdBreak';
 import type { CompanionAd } from 'theoplayer';
+import { AdIntegrationKind, CustomAdIntegrationKind } from '../source/ads/Ads';
 
 /**
  * Represents a VAST creative. It is either a linear or non-linear ad.
@@ -17,15 +18,12 @@ export interface Ad {
   adSystem: string | undefined;
 
   /**
-   * The integration of the ad, represented by a value from the following list:
-   * <br/> - `'theo'`
-   * <br/> - `'google-ima'`
-   * <br/> - `'google-dai'`
-   * <br/> - `'freewheel'`
+   * The integration of the ad, represented by a value from {@link AdIntegrationKind}
+   * or {@link CustomAdIntegrationKind | the identifier of a custom integration}.
    *
-   * @defaultValue `'theo'`
+   * @defaultValue `'csai'`
    */
-  integration?: string;
+  integration?: AdIntegrationKind | CustomAdIntegrationKind;
 
   /**
    * The type of the ad, represented by a value from the following list:

--- a/src/api/ads/AdBreak.ts
+++ b/src/api/ads/AdBreak.ts
@@ -5,6 +5,7 @@
  * @public
  */
 import type { Ad } from './Ad';
+import { AdIntegrationKind, CustomAdIntegrationKind } from '../source/ads/Ads';
 
 /**
  * Represents an ad break in the VMAP specification or an ad pod in the VAST specification.
@@ -14,13 +15,10 @@ import type { Ad } from './Ad';
  */
 export interface AdBreak {
   /**
-   * The integration of the ad break, represented by a value from the following list:
-   * <br/> - `'theo'`
-   * <br/> - `'google-ima'`
-   * <br/> - `'google-dai'`
-   * <br/> - `'freewheel'`
+   * The integration of the ad break, represented by a value from {@link AdIntegrationKind}
+   * or {@link CustomAdIntegrationKind | the identifier of a custom integration}.
    */
-  integration: string | undefined;
+  integration: AdIntegrationKind | CustomAdIntegrationKind | undefined;
 
   /**
    * List of ads which will be played sequentially at the ad break's time offset.

--- a/src/api/source/ads/Ads.ts
+++ b/src/api/source/ads/Ads.ts
@@ -44,8 +44,6 @@ export interface AdSource {
 export interface AdDescription {
   /**
    * The integration of the ad break.
-   *
-   * @defaultValue `'csai'`
    */
   integration?: AdIntegrationKind | CustomAdIntegrationKind;
 

--- a/src/api/source/ads/Ads.ts
+++ b/src/api/source/ads/Ads.ts
@@ -47,7 +47,7 @@ export interface AdDescription {
    *
    * @defaultValue `'csai'`
    */
-  integration?: AdIntegrationKind;
+  integration?: AdIntegrationKind | CustomAdIntegrationKind;
 
   /**
    * Whether the ad replaces playback of the content.
@@ -116,3 +116,10 @@ export enum AdIntegrationKind {
   csai = 'csai',
   theoads = 'theoads',
 }
+
+/**
+ * The identifier of a custom ad integration.
+ *
+ * @category Ads
+ */
+export type CustomAdIntegrationKind = string & {};

--- a/src/internal/adapter/theolive/TheoLiveWebAdapter.ts
+++ b/src/internal/adapter/theolive/TheoLiveWebAdapter.ts
@@ -10,17 +10,8 @@ export class TheoLiveWebAdapter implements TheoLiveAPI {
   }
 
   get latencies(): Promise<HespLatencies> {
-    const webLatencies = this._player.hesp?.latencies;
-    if (webLatencies) {
-      return Promise.resolve({
-        engineLatency: webLatencies?.engine,
-        distributionLatency: webLatencies?.distribution,
-        playerLatency: webLatencies?.player,
-        theoliveLatency: webLatencies?.theolive,
-      });
-    } else {
-      return Promise.reject<HespLatencies>('latencies not available');
-    }
+    console.warn('The THEOlive latencies metrics are not available');
+    return Promise.resolve({});
   }
 
   set authToken(token: string) {


### PR DESCRIPTION
Added support for `CustomAdIntegrationKind`, allowing custom ad integrations on top of the player API.

> [!CAUTION]
> This requires native player SDK v11.4 
