### PR TITLE
Destroy player and listeners on web unmount

### DIFF
--- a/src/internal/THEOplayerView.web.tsx
+++ b/src/internal/THEOplayerView.web.tsx
@@ -32,12 +32,11 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
       // Adapt native player to react-native player.
       adapter.current = new THEOplayerWebAdapter(player.current, config);
 
-      // Expose players for easy access
+      // Expose players for easy access from the browser console.
       // @ts-ignore
       window.player = adapter.current;
-
       // @ts-ignore
-      window.nativePlayer = player;
+      window.nativePlayer = player.current;
 
       // Notify the player is ready
       onPlayerReady?.(adapter.current);
@@ -45,11 +44,26 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
 
     // Clean-up
     return () => {
-      // Notify the player will be destroyed.
-      if (adapter?.current && onPlayerDestroy) {
-        onPlayerDestroy(adapter?.current);
+      const adapterRef = adapter.current;
+      const playerRef = player.current;
+      if (adapterRef) {
+        onPlayerDestroy?.(adapterRef);
+        adapterRef.destroy();
+        adapter.current = null;
+      } else if (playerRef) {
+        // Adapter construction failed between `new ChromelessPlayer(...)`
+        // and `new THEOplayerWebAdapter(...)` — destroy the raw player ourselves.
+        playerRef.destroy();
       }
-      adapter?.current?.destroy();
+      player.current = null;
+      if (typeof window !== 'undefined') {
+        // Only clear globals if they still point to our instances — a second
+        // player may have mounted and overwritten them.
+        // @ts-ignore
+        if (window.player === adapterRef) window.player = undefined;
+        // @ts-ignore
+        if (window.nativePlayer === playerRef) window.nativePlayer = undefined;
+      }
     };
     // TODO: Follow the rules of react hooks, to be fixed in next major because it's a breaking change for some customers.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/internal/adapter/THEOplayerWebAdapter.ts
+++ b/src/internal/adapter/THEOplayerWebAdapter.ts
@@ -385,6 +385,7 @@ export class THEOplayerWebAdapter extends DefaultEventDispatcher<PlayerEventMap>
     this.dispatchEvent(new BaseEvent(PlayerEventType.DESTROY));
     this._eventForwarder?.unload();
     this._mediaSession?.destroy();
+    this._presentationModeManager?.destroy();
     document.removeEventListener('visibilitychange', this.onVisibilityChange);
     this._eventForwarder = undefined;
     this._mediaSession = undefined;
@@ -393,6 +394,12 @@ export class THEOplayerWebAdapter extends DefaultEventDispatcher<PlayerEventMap>
     this._player?.removeEventListener('dimensionchange', this.onPlayerDimensionChange);
     this._player?.destroy();
     this._player = undefined;
+
+    // @ts-ignore
+    if (typeof window !== 'undefined' && window.__onGCastApiAvailable) {
+      // @ts-ignore
+      window.__onGCastApiAvailable = undefined;
+    }
   }
 
   private readonly onVisibilityChange = () => {

--- a/src/internal/adapter/THEOplayerWebAdapter.ts
+++ b/src/internal/adapter/THEOplayerWebAdapter.ts
@@ -395,6 +395,9 @@ export class THEOplayerWebAdapter extends DefaultEventDispatcher<PlayerEventMap>
     this._player?.destroy();
     this._player = undefined;
 
+    // We clear this global always. If there are two players on the same page,
+    // this can also clear the callback of the other player. This is fine,
+    // because using Cast with multiple players on web is not supported.
     // @ts-ignore
     if (typeof window !== 'undefined' && window.__onGCastApiAvailable) {
       // @ts-ignore

--- a/src/internal/adapter/web/WebPresentationModeManager.ts
+++ b/src/internal/adapter/web/WebPresentationModeManager.ts
@@ -65,6 +65,14 @@ export class WebPresentationModeManager {
     }
   }
 
+  destroy(): void {
+    if (fullscreenAPI !== undefined) {
+      document.removeEventListener(fullscreenAPI.fullscreenchange_, this.updatePresentationMode);
+      document.removeEventListener(fullscreenAPI.fullscreenerror_, this.updatePresentationMode);
+    }
+    this._player?.presentation?.removeEventListener('presentationmodechange', this.updatePresentationMode);
+  }
+
   private updatePresentationMode = () => {
     // detect new presentation mode
     let newPresentationMode: PresentationMode = PresentationMode.inline;


### PR DESCRIPTION
## Problem

On web, mounting and unmounting `<THEOplayerView>` leaks the full player graph (`ChromelessPlayer`, `THEOplayerWebAdapter`, its sub-managers, the underlying video element + buffers, registered listeners). Repeated mount/unmount cycles (i've tested 10 mounts and unmounts) accumulate one detached player per cycle. On memory-constrained environments (webOS TVs, low-end web) this leads to RAM exhaustion.

Four independent retainers were keeping the graph alive after unmount:

1. **The component's cleanup never destroyed the raw `ChromelessPlayer` or nulled either ref.** `adapter.destroy()` was called, but `player.current` and `adapter.current` remained populated.
2. **`window.player` and `window.nativePlayer` were assigned on mount and never cleared on unmount**, pinning the last-rendered adapter and player globally for the lifetime of the page.
3. **`WebPresentationModeManager` registered three listeners** — two on `document` (`fullscreenchange`, `fullscreenerror`) and one on `player.presentation` (`presentationmodechange`) — **with no matching teardown.** The manager (and its `_player` field) was kept alive by `document`'s listener table.
4. **`THEOplayerWebAdapter.destroy()` never cleared `window.__onGCastApiAvailable`.** When the Cast Sender SDK is loaded (via `chromeless.js`), this global is assigned a closure that captures the player; until cleared, the closure retains the player.

## Fix

- **`THEOplayerView.web.tsx`** — rework the effect cleanup to destroy the adapter (which internally destroys the player), null both refs, and clear the `window.player` / `window.nativePlayer` globals — but **only** if they still point to *this* component's instances (identity-guarded, so a second mounted player isn't nulled by the first one's cleanup). Also fixes a pre-existing bug where `window.nativePlayer = player` assigned the React ref wrapper rather than the underlying `ChromelessPlayer`.
- **`WebPresentationModeManager.ts`** — add `destroy()` that removes all three listeners. Uses the stable arrow-bound `updatePresentationMode` reference so removal still matches the original function under monkey-patched `addEventListener` wrappers (e.g. Sentry's, which keys by the original function).
- **`THEOplayerWebAdapter.ts`** — invoke `_presentationModeManager.destroy()` from the adapter's `destroy()`, ordered before `_player.destroy()` so the listener on `_player.presentation` is removed while the player is still live. Also clears `window.__onGCastApiAvailable`.

## Behaviour change note

The debug globals `window.player` / `window.nativePlayer` are still assigned on mount as before, but now cleared on unmount (with the identity guard). Any consumer code that reads these globals *after* the player screen unmounts will now see `undefined`. 
