### PR TITLE
Release v11.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [11.3.0] - 26-06-18
+
 ### Added
 
 - Added Android support for `ABRConfiguration.preferredMaximumResolution`, mirroring the existing iOS behaviour. Set to `(0,0)` to remove the cap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-theoplayer",
-  "version": "11.2.1",
+  "version": "11.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-theoplayer",
-      "version": "11.2.1",
+      "version": "11.3.0",
       "license": "BSD-3-Clause-Clear",
       "dependencies": {
         "@theoplayer/cmcd-connector-web": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-theoplayer",
-  "version": "11.2.1",
+  "version": "11.3.0",
   "description": "A THEOplayer video component for react-native.",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

Release branch for **v11.3.0**.

### Changelog

#### Added

- Added Android support for `ABRConfiguration.preferredMaximumResolution`, mirroring the existing iOS behaviour. Set to `(0,0)` to remove the cap.
- Added basic support for CMCD event mode reporting of DRM and ad events.
- Added bridging of the `hlsDateRange` property from `PlayerConfiguration` to Android's `THEOplayerConfig`.

#### Fixed

- Fixed an issue on Android where `GoogleImaConfiguration.sessionId` was not properly passed.

---

### 🍃 Haiku

*Streams find their new way,*
*Android learns what iOS knew—*
*Resolution blooms.*

Link to Devin session: https://dolby.devinenterprise.com/sessions/847bdfa61f8f4ce89484db98a5a54e51
Requested by: @tvanlaerhoven