### PR TITLE
feat: bridge V3 discovery response properties to React Native

### DIFF
--- a/android/src/main/java/com/theoplayer/theolive/EndpointAdapter.kt
+++ b/android/src/main/java/com/theoplayer/theolive/EndpointAdapter.kt
@@ -15,7 +15,9 @@ private const val PROP_MILLICAST_SUBSCRIBER_TOKEN ="subscriberToken"
 private const val PROP_MILLICAST_DIRECTOR_URL = "directorUrl"
 private const val PROP_HESP_SRC = "hespSrc"
 private const val PROP_HLS_SRC = "hlsSrc"
+private const val PROP_HLS_MPEG_TS_SRC = "hlsMpegTsSrc"
 private const val PROP_AD_SRC = "adSrc"
+private const val PROP_DAI_ASSET_KEY = "daiAssetKey"
 private const val PROP_CDN = "cdn"
 private const val PROP_TARGET_LATENCY = "targetLatency"
 private const val PROP_WEIGHT = "weight"
@@ -44,7 +46,9 @@ object EndpointAdapter {
       endPoint.millicastSrc?.let { putMap(PROP_MILLICAST_SRC, fromEndPointMillicastSource(it)) }
       endPoint.hespSrc?.let { putString(PROP_HESP_SRC, it) }
       endPoint.hlsSrc?.let { putString(PROP_HLS_SRC, it) }
+      endPoint.hlsMpegTsSrc?.let { putString(PROP_HLS_MPEG_TS_SRC, it) }
       endPoint.adSrc?.let { putString(PROP_AD_SRC, it) }
+      endPoint.daiAssetKey?.let { putString(PROP_DAI_ASSET_KEY, it) }
       endPoint.cdn?.let { putString(PROP_CDN, it) }
       endPoint.targetLatency?.let { putDouble(PROP_TARGET_LATENCY, it) }
       putInt(PROP_WEIGHT, endPoint.weight)

--- a/ios/theolive/THEOplayerRCTTHEOliveEventAdapter.swift
+++ b/ios/theolive/THEOplayerRCTTHEOliveEventAdapter.swift
@@ -9,9 +9,11 @@ import THEOplayerTHEOliveIntegration
 
 let PROP_ENDPOINT_HESP_SRC: String = "hespSrc"
 let PROP_ENDPOINT_HLS_SRC: String = "hlsSrc"
+let PROP_ENDPOINT_HLS_MPEG_TS_SRC: String = "hlsMpegTsSrc"
 let PROP_ENDPOINT_MILLICAST_SRC: String = "millicastSrc"
 let PROP_ENDPOINT_CDN: String = "cdn"
 let PROP_ENDPOINT_AD_SRC: String = "adSrc"
+let PROP_ENDPOINT_DAI_ASSET_KEY: String = "daiAssetKey"
 let PROP_ENDPOINT_WEIGHT: String = "weight"
 let PROP_ENDPOINT_PRIORITY: String = "priority"
 let PROP_ENDPOINT_CONTENT_PROTECTION: String = "contentProtection"
@@ -46,6 +48,9 @@ class THEOplayerRCTTHEOliveEventAdapter {
         if let hlsSrc = endpoint.hlsSrc {
             endpointData[PROP_ENDPOINT_HLS_SRC] = hlsSrc
         }
+        if let hlsMpegTsSrc = endpoint.hlsMpegTsSrc {
+            endpointData[PROP_ENDPOINT_HLS_MPEG_TS_SRC] = hlsMpegTsSrc
+        }
         if let millicastSrc = endpoint.millicastSrc {
             endpointData[PROP_ENDPOINT_MILLICAST_SRC] = millicastSrc.toJSONEncodableDictionary()
         }
@@ -54,6 +59,9 @@ class THEOplayerRCTTHEOliveEventAdapter {
         }
         if let adSrc = endpoint.adSrc {
             endpointData[PROP_ENDPOINT_AD_SRC] = adSrc
+        }
+        if let daiAssetKey = endpoint.daiAssetKey {
+            endpointData[PROP_ENDPOINT_DAI_ASSET_KEY] = daiAssetKey
         }
         if let contentProtection = endpoint.channelContentProtection {
             endpointData[PROP_ENDPOINT_CONTENT_PROTECTION] = THEOplayerRCTTHEOliveEventAdapter.fromContentProtection(contentProtection: contentProtection)

--- a/src/api/theolive/TheoLiveEndpoint.ts
+++ b/src/api/theolive/TheoLiveEndpoint.ts
@@ -1,3 +1,4 @@
+import { TheoLiveDistribution } from './TheoLiveDistribution';
 import { WebrtcOptions } from './WebrtcOptions';
 
 export interface EndpointMillicastSource {
@@ -16,14 +17,80 @@ export interface EndpointMillicastSource {
  * @public
  */
 export interface TheoLiveEndpoint {
+  /**
+   * The source of this endpoint.
+   *
+   * @remarks
+   * For most endpoint types, this is the source URL string.
+   * For millicast endpoints, this is a {@link EndpointMillicastSource} object.
+   *
+   * @platform web
+   */
+  src?: string | EndpointMillicastSource;
+
+  /**
+   * The type of source (e.g. 'hesp', 'hls', 'hlsMpegTs', 'millicast', 'dai').
+   *
+   * @platform web
+   */
+  srcType?: string;
+
+  /**
+   * The provider of this endpoint (e.g. 'optiview', 'mediakind').
+   *
+   * @platform web
+   */
+  provider?: string;
+
+  /**
+   * @deprecated Use {@link src} with {@link srcType} `'millicast'` instead. Only populated for V1/V2 distributions.
+   */
   millicastSrc?: EndpointMillicastSource;
+
+  /**
+   * @deprecated Use {@link src} with {@link srcType} `'hesp'` instead. Only populated for V1/V2 distributions.
+   */
   hespSrc?: string;
+
+  /**
+   * @deprecated Use {@link src} with {@link srcType} `'hls'` instead. Only populated for V1/V2 distributions.
+   */
   hlsSrc?: string;
+
+  /**
+   * @deprecated Use {@link src} with {@link srcType} `'hlsMpegTs'` instead. Only populated for V1/V2 distributions.
+   */
+  hlsMpegTsSrc?: string;
+
+  /**
+   * @deprecated Only populated for V1/V2 distributions.
+   */
   adSrc?: string;
+
+  /**
+   * @deprecated Only populated for V1/V2 distributions.
+   */
+  daiAssetKey?: string;
+
   cdn?: string;
+
+  /**
+   * The target latency for this endpoint, in seconds.
+   *
+   * @platform android
+   */
+  targetLatency?: number;
+
   weight: number;
   priority: number;
   contentProtection?: ChannelDrmConfigResponse;
+
+  /**
+   * The distribution associated with this endpoint.
+   *
+   * @platform web
+   */
+  distribution?: TheoLiveDistribution;
 }
 
 /**

--- a/src/api/theolive/TheoLiveEndpoint.ts
+++ b/src/api/theolive/TheoLiveEndpoint.ts
@@ -36,40 +36,17 @@ export interface TheoLiveEndpoint {
   srcType?: string;
 
   /**
-   * The provider of this endpoint (e.g. 'optiview', 'mediakind').
+   * The provider of this endpoint (e.g. 'optiview').
    *
    * @platform web
    */
   provider?: string;
 
-  /**
-   * @deprecated Use {@link src} with {@link srcType} `'millicast'` instead. Only populated for V1/V2 distributions.
-   */
   millicastSrc?: EndpointMillicastSource;
-
-  /**
-   * @deprecated Use {@link src} with {@link srcType} `'hesp'` instead. Only populated for V1/V2 distributions.
-   */
   hespSrc?: string;
-
-  /**
-   * @deprecated Use {@link src} with {@link srcType} `'hls'` instead. Only populated for V1/V2 distributions.
-   */
   hlsSrc?: string;
-
-  /**
-   * @deprecated Use {@link src} with {@link srcType} `'hlsMpegTs'` instead. Only populated for V1/V2 distributions.
-   */
   hlsMpegTsSrc?: string;
-
-  /**
-   * @deprecated Only populated for V1/V2 distributions.
-   */
   adSrc?: string;
-
-  /**
-   * @deprecated Only populated for V1/V2 distributions.
-   */
   daiAssetKey?: string;
 
   cdn?: string;


### PR DESCRIPTION
## Summary

Exposes missing THEOlive endpoint properties from the native SDKs through the React Native bridge.

**New V3 properties** (web-only until native SDKs add support):
- `src: string | EndpointMillicastSource` — generic source replacing legacy format-specific fields
- `srcType: string` — source type discriminator (`'hesp'`, `'hls'`, `'hlsMpegTs'`, `'millicast'`, `'dai'`)
- `provider: string` — endpoint provider (e.g. `'optiview'`, `'mediakind'`)
- `distribution: TheoLiveDistribution` — inline distribution on the endpoint

**Missing legacy properties** now bridged on Android + iOS:
- `hlsMpegTsSrc: string` — HLS MPEG-TS source URL
- `daiAssetKey: string` — DAI asset key

**Already bridged on Android, now exposed in TypeScript**:
- `targetLatency: number` — target latency in seconds (was in `EndpointAdapter.kt` but missing from `TheoLiveEndpoint` interface)

### Changes

`TheoLiveEndpoint` interface gains 7 optional properties. Legacy fields are marked `@deprecated` with migration guidance toward `src`/`srcType`.

Android `EndpointAdapter.fromEndpoint()` now forwards `hlsMpegTsSrc` and `daiAssetKey` from the native `Endpoint` object.

iOS `THEOplayerRCTTHEOliveEventAdapter.fromEndpoint()` now forwards `hlsMpegTsSrc` and `daiAssetKey` from `EndpointAPI`.

Link to Devin session: https://dolby.devinenterprise.com/sessions/788fe10ebc82492d9276207da6447be8
Requested by: @tvanlaerhoven
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-theoplayer/pull/852" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->