### PR TITLE
repro: iOS playback stall after IMA CSAI preroll with ads.theoads enabled

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -9,6 +9,13 @@ source 'https://cdn.cocoapods.org/'
 # source 'https://github.com/THEOplayer/cocoapods-specs'
 
 prepare_react_native_project!
+
+# The react-native-theoplayer.json feature config only resolves correctly when the package
+# is installed from npm. With the local ".." path the podspec resolves __dir__ to the repo
+# root and the config file is never found. Set THEO_FEATURES here so the podspec picks up
+# the required integrations via its env-var path instead.
+ENV["THEO_FEATURES"] = "GOOGLE_IMA,THEO_ADS,SIDELOADED_TEXTTRACKS,MILLICAST"
+
 config = use_native_modules!
 
 linkage = ENV['USE_FRAMEWORKS']

--- a/example/src/custom/sources.json
+++ b/example/src/custom/sources.json
@@ -325,6 +325,35 @@
     }
   },
   {
+    "name": "HLS - CSAI - Google IMA - two pre-rolls (PiP repro)",
+    "os": ["ios", "web"],
+    "source": {
+      "sources": [
+        {
+          "src": "https://cdn.theoplayer.com/video/elephants-dream/playlistCorrectionENG.m3u8",
+          "type": "application/x-mpegurl"
+        }
+      ],
+      "ads": [
+        {
+          "integration": "google-ima",
+          "sources": "https://cdn.theoplayer.com/demos/ads/vast/dfp-preroll-no-skip.xml",
+          "timeOffset": "start"
+        },
+        {
+          "integration": "google-ima",
+          "sources": "https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/external/single_ad_samples&sz=640x480&cust_params=sample_ct%3Dlinear&ciu_szs=300x250&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=",
+          "timeOffset": "start"
+        }
+      ],
+      "poster": "https://cdn.theoplayer.com/react-native-theoplayer/temp/THEOPlayer-1200x675.png",
+      "metadata": {
+        "title": "Elephants Dream with two prerolls",
+        "artist": "THEOplayer"
+      }
+    }
+  },
+  {
     "name": "HLS - SGAI (THEOads)",
     "os": ["web"],
     "source": {

--- a/example/src/custom/sources.json
+++ b/example/src/custom/sources.json
@@ -596,6 +596,24 @@
     }
   },
   {
+    "name": "REPRO: theoads:true + IMA CSAI preroll (iOS stall)",
+    "os": ["ios"],
+    "source": {
+      "sources": {
+        "src": "https://v-theo.hudl.com/signaling-service/api/v1/510c4287-512a-4359-964f-7f67bf82cf36/hls/video.m3u8",
+        "type": "application/x-mpegurl",
+        "hlsDateRange": true
+      },
+      "ads": [
+        {
+          "integration": "google-ima",
+          "sources": "https://cdn.theoplayer.com/demos/ads/vast/dfp-preroll-no-skip.xml",
+          "timeOffset": "start"
+        }
+      ]
+    }
+  },
+  {
     "name": "Millicast",
     "os": ["android"],
     "source": {


### PR DESCRIPTION
## Summary

This PR adds a source entry to reproduce a bug: on **physical iOS only**, playback stalls at ~1s after a Google IMA CSAI preroll ends when `ads: { theoads: true }` is set in `PlayerConfiguration`. No error event fires and the player does not recover.

## Repro steps

1. Run on a **physical iPhone** — does not repro on simulator
2. `cd example/ios && pod install` — the `THEO_FEATURES` env var set in the Podfile ensures `GOOGLE_IMA` and `THEO_ADS` are linked as pod-level `s.dependency` entries (the config-file path only resolves when the package is installed from npm, not the local `..` path)
3. Build and launch with your own THEOplayer license configured in `App.tsx`
4. Select **"REPRO: theoads:true + IMA CSAI preroll (iOS stall)"** from the source picker
5. IMA preroll plays to completion
6. Playback stalls at ~currentTime ≈ 1s — player frozen, no error event

## Root mechanism (as we understand it)

- `ads: { theoads: true }` causes `initTHEOadsIntegration()` to run unconditionally in `THEOplayerRCTView.swift`, installing `AVPlayerInterstitialEventController`
- The HLS stream contains `#EXT-X-DATERANGE CLASS="com.theoplayer.theoads.interstitial"` markers, arming the controller with scheduled events
- When IMA CSAI ends and swaps `AVPlayerItem` for the content item, the two conflict — the player freezes with no recovery

## Changes

- `example/src/custom/sources.json` — repro source (HLS stream with THEOads DATERANGE markers + IMA CSAI preroll at `timeOffset: "start"`)
- `example/ios/Podfile` — sets `THEO_FEATURES` env var so the podspec includes `GOOGLE_IMA` and `THEO_ADS` as pod-level dependencies