### PR TITLE
repro: iOS playback stall after IMA CSAI preroll with ads.theoads enabled

### DIFF
--- a/example/src/custom/sources.json
+++ b/example/src/custom/sources.json
@@ -547,6 +547,26 @@
     }
   },
   {
+    "name": "REPRO: theoads:true + IMA CSAI preroll (iOS stall)",
+    "os": ["ios"],
+    "source": {
+      "sources": [
+        {
+          "src": "https://v-theo.hudl.com/signaling-service/api/v1/510c4287-512a-4359-964f-7f67bf82cf36/hls/video.m3u8",
+          "type": "application/x-mpegurl",
+          "hlsDateRange": true
+        }
+      ],
+      "ads": [
+        {
+          "integration": "google-ima",
+          "sources": "https://cdn.theoplayer.com/demos/ads/vast/dfp-preroll-no-skip.xml",
+          "timeOffset": "start"
+        }
+      ]
+    }
+  },
+  {
     "name": "Millicast",
     "os": ["ios", "web"],
     "source": {


### PR DESCRIPTION
## Summary

Adds a source to reproduce a bug where playback stalls at ~1s after a Google IMA CSAI preroll ends when `ads: { theoads: true }` is set in `PlayerConfiguration`. Physical iOS device only. No error event fires and the player does not recover.

## Repro

1. Select **"REPRO: theoads:true + IMA CSAI preroll (iOS stall)"** from the source picker
2. IMA preroll plays to completion
3. Playback stalls at ~1s — player frozen, no error