### PR TITLE
Update ABR docs

### DIFF
--- a/doc/abr.md
+++ b/doc/abr.md
@@ -33,13 +33,17 @@ on the chosen strategy, as well as various parameters of the playback buffer.
 />
 ```
 
-| Property               | Description                                                                                                                                                     | Supported Platforms |
-|------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
-| `strategy`             | The adaptive bitrate strategy. Possible values are `'performance'`, `'quality'`, `'bandwidth'` or a `ABRStrategyConfiguration` object. Default is **bandwidth** | Android & Web       |
-| `targetBuffer`         | The amount that the player should buffer ahead of the current playback position, in seconds. Default is **20**s.                                                | Android & Web       |
-| `bufferLookbackWindow` | The amount of data which the player should keep in its buffer before the current playback position, in seconds. Default is **30**s.                             | Web                 |
-| `maxBufferLength`      | The maximum length of the player's buffer, in seconds.                                                                                                          | Web                 |                 |
-| `preferredMaximumResolution` | A preferred upper limit on the resolution of the video to be downloaded. `(0,0)` (the default) removes the cap.                                           | Android & iOS       |
+| Property                     | Description                                                                                                                                                      | Supported Platforms |
+|------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|
+| `strategy`                   | The adaptive bitrate strategy. Possible values are `'performance'`, `'quality'`, `'bandwidth'` or a `ABRStrategyConfiguration` object. Default is **bandwidth**. | Android/Web/iOS*    |
+| `targetBuffer`               | The amount that the player should buffer ahead of the current playback position, in seconds. Default is **20**s.                                                 | Android/Web/iOS     |
+| `bufferLookbackWindow`       | The amount of data which the player should keep in its buffer before the current playback position, in seconds. Default is **30**s.                              | Web                 |
+| `maxBufferLength`            | The maximum length of the player's buffer, in seconds.                                                                                                           | Web                 |
+| `preferredPeakBitRate`       | A preferred upper limit on the bandwidth of the video to be downloaded, in bits per second. Defaults to `0`, which indicates there is no limit.                  | iOS                 |
+| `preferredMaximumResolution` | A preferred upper limit on the resolution of the video to be downloaded. `(0,0)` (the default) removes the cap.                                                  | Android & iOS       |
+
+\* On native iOS/tvOS, `strategy` will only work with THEOlive and Millicast streams, and will
+not have any effect for other types of streams.
 
 When specifying the strategy, apart from the values `'performance'`, `'quality'`, `'bandwidth'`,
 an `ABRStrategyConfiguration`

--- a/src/api/abr/ABRConfiguration.ts
+++ b/src/api/abr/ABRConfiguration.ts
@@ -70,7 +70,9 @@ export interface ABRConfiguration {
    *
    * @defaultValue `'bandwidth'`
    *
-   * @platform web,android
+   * @remarks
+   * <br/> - On native iOS/tvOS, this configuration will only work with THEOlive and Millicast streams and will not have any effect for other types of streams.
+   * <br/> - On native iOS/tvOS with Millicast streams, this only applies once during connection establishment; make sure to set it before you start playback.
    */
   strategy?: ABRStrategy;
 
@@ -80,8 +82,6 @@ export interface ABRConfiguration {
    * @defaultValue `20`
    *
    * @remarks
-   * <br/> - Before v4.3.0: This duration has a maximum of 60 seconds.
-   * <br/> - After v4.3.0: This duration has no maximum.
    * <br/> - The player might reduce or ignore the configured amount because of device or performance constraints.
    */
   targetBuffer?: number;
@@ -119,6 +119,9 @@ export interface ABRConfiguration {
    * If network bandwidth consumption cannot be lowered to meet the preferredPeakBitRate, it will be reduced as much as possible while continuing to play the item.
    *
    * @platform ios
+   * 
+   * @remarks
+   * <br/> - On native iOS/tvOS with Millicast streams, this only applies once during connection establishment; make sure to set it before you start playback.
    */
   preferredPeakBitRate?: number;
 


### PR DESCRIPTION
This PR updates the ABR docs and some API descriptions:
- `targetBuffer` is now correctly documented to be supported on all platforms.
- Adds `preferredPeakBitRate` to the ABR doc.
- Adds extra remarks for some ABR APIs. 