### PR TITLE
fix(web): forward contentprotectionerror events to React Native layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue on Web where `contentprotectionerror` events were not dispatched.
+
 ## [11.3.0] - 26-06-18
 
 ### Added

--- a/src/internal/adapter/WebEventForwarder.ts
+++ b/src/internal/adapter/WebEventForwarder.ts
@@ -6,6 +6,7 @@ import type {
   CastStateChangeEvent,
   ChromecastErrorEvent,
   ChromelessPlayer,
+  ContentProtectionErrorEvent as NativeContentProtectionErrorEvent,
   CurrentSourceChangeEvent as NativeCurrentSourceChangeEvent,
   DimensionChangeEvent as NativeDimensionChangeEvent,
   DurationChangeEvent as NativeDurationChangeEvent,
@@ -97,6 +98,7 @@ export class WebEventForwarder {
     this._player.addEventListener('loadeddata', this.onLoadedData);
     this._player.addEventListener('loadedmetadata', this.onLoadedMetadata);
     this._player.addEventListener('error', this.onError);
+    this._player.addEventListener('contentprotectionerror', this.onContentProtectionError);
     this._player.addEventListener('progress', this.onProgress);
     this._player.addEventListener('play', this.onPlay);
     this._player.addEventListener('canplay', this.onCanPlay);
@@ -148,6 +150,7 @@ export class WebEventForwarder {
     this._player.removeEventListener('loadeddata', this.onLoadedData);
     this._player.removeEventListener('loadedmetadata', this.onLoadedMetadata);
     this._player.removeEventListener('error', this.onError);
+    this._player.removeEventListener('contentprotectionerror', this.onContentProtectionError);
     this._player.removeEventListener('progress', this.onProgress);
     this._player.removeEventListener('canplay', this.onCanPlay);
     this._player.removeEventListener('play', this.onPlay);
@@ -219,6 +222,15 @@ export class WebEventForwarder {
   };
 
   private readonly onError = (event: NativeErrorEvent) => {
+    this._facade.dispatchEvent(
+      new DefaultErrorEvent({
+        errorCode: event.errorObject.code.toString(),
+        errorMessage: event.errorObject.message,
+      }),
+    );
+  };
+
+  private readonly onContentProtectionError = (event: NativeContentProtectionErrorEvent) => {
     this._facade.dispatchEvent(
       new DefaultErrorEvent({
         errorCode: event.errorObject.code.toString(),


### PR DESCRIPTION
## Summary

The web THEOplayer SDK fires `contentprotectionerror` as a **separate event** from `error`. `WebEventForwarder` only listened for `'error'`, so DRM/content protection errors were silently dropped on web.

On native (Android/iOS), content protection errors already arrive as regular `PlayerEventType.ERROR` events (with `ErrorCode.CONTENT_PROTECTION_ERROR`). This fix makes web consistent by forwarding `contentprotectionerror` as `PlayerEventType.ERROR`:

```diff
// WebEventForwarder.ts — addEventListeners()
  this._player.addEventListener('error', this.onError);
+ this._player.addEventListener('contentprotectionerror', this.onContentProtectionError);

// New handler — maps ContentProtectionErrorEvent → DefaultErrorEvent
+ private readonly onContentProtectionError = (event: NativeContentProtectionErrorEvent) => {
+   this._facade.dispatchEvent(
+     new DefaultErrorEvent({
+       errorCode: event.errorObject.code.toString(),
+       errorMessage: event.errorObject.message,
+     }),
+   );
+ };
```

Link to Devin session: https://dolby.devinenterprise.com/sessions/4f3f8d74c30b45dfb651a76c65693a83
Requested by: @tvanlaerhoven
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-theoplayer/pull/857" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->