### PR TITLE
feat: add contentprotectionerror player event on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Added `contentprotectionerror` player event on Web, Android, and iOS platforms.
+
 ## [11.4.0] - 26-07-06
 
 ### Fixed

--- a/android/src/main/java/com/theoplayer/PlayerEventEmitter.kt
+++ b/android/src/main/java/com/theoplayer/PlayerEventEmitter.kt
@@ -85,6 +85,7 @@ private const val EVENT_THEOLIVE_EVENT = "onNativeTHEOliveEvent"
 private const val EVENT_THEOADS_EVENT = "onNativeTHEOadsEvent"
 private const val EVENT_PRESENTATIONMODECHANGE = "onNativePresentationModeChange"
 private const val EVENT_VOLUMECHANGE = "onNativeVolumeChange"
+private const val EVENT_CONTENTPROTECTIONERROR = "onNativeContentProtectionError"
 private const val EVENT_DIMENSIONCHANGE = "onNativeDimensionChange"
 private const val EVENT_VIDEORESIZE = "onNativeVideoResize"
 
@@ -132,6 +133,7 @@ class PlayerEventEmitter internal constructor(
     EVENT_THEOADS_EVENT,
     EVENT_PRESENTATIONMODECHANGE,
     EVENT_VOLUMECHANGE,
+    EVENT_CONTENTPROTECTIONERROR,
     EVENT_DIMENSIONCHANGE,
     EVENT_VIDEORESIZE
   )
@@ -171,6 +173,7 @@ class PlayerEventEmitter internal constructor(
       EVENT_THEOADS_EVENT,
       EVENT_PRESENTATIONMODECHANGE,
       EVENT_VOLUMECHANGE,
+      EVENT_CONTENTPROTECTIONERROR,
       EVENT_DIMENSIONCHANGE,
       EVENT_VIDEORESIZE
     )
@@ -246,6 +249,8 @@ class PlayerEventEmitter internal constructor(
       EventListener { event: PresentationModeChange -> onPresentationModeChange(event) }
     playerListeners[PlayerEventTypes.VOLUMECHANGE] =
       EventListener { event: VolumeChangeEvent -> onVolumeChange(event) }
+    playerListeners[PlayerEventTypes.CONTENTPROTECTIONERROR] =
+      EventListener { event: ContentProtectionErrorEvent -> onContentProtectionError(event) }
     playerListeners[PlayerEventTypes.RESIZE] =
       EventListener { event: ResizeEvent -> onResize(event) }
     textTrackListeners[TextTrackListEventTypes.ADDTRACK] =
@@ -476,6 +481,13 @@ class PlayerEventEmitter internal constructor(
     receiveEvent(
       EVENT_DIMENSIONCHANGE,
       PayloadBuilder().size(width, height).build()
+    )
+  }
+
+  private fun onContentProtectionError(event: ContentProtectionErrorEvent) {
+    receiveEvent(
+      EVENT_CONTENTPROTECTIONERROR,
+      PayloadBuilder().error(event.errorObject.code.id.toString(), event.errorObject.message).build()
     )
   }
 

--- a/ios/THEOplayerRCTBridge.m
+++ b/ios/THEOplayerRCTBridge.m
@@ -47,6 +47,7 @@ RCT_EXPORT_VIEW_PROPERTY(onNativeMediaTrackEvent, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativeDeviceOrientationChanged, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativePlayerReady, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativePresentationModeChange, RCTDirectEventBlock);
+RCT_EXPORT_VIEW_PROPERTY(onNativeContentProtectionError, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativeDimensionChange, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativeVideoResize, RCTDirectEventBlock);
 RCT_EXPORT_VIEW_PROPERTY(onNativeAdEvent, RCTDirectEventBlock);

--- a/ios/THEOplayerRCTMainEventHandler.swift
+++ b/ios/THEOplayerRCTMainEventHandler.swift
@@ -30,6 +30,7 @@ public class THEOplayerRCTMainEventHandler {
     var onNativeRateChange: RCTDirectEventBlock?
     var onNativeWaiting: RCTDirectEventBlock?
     var onNativeCanPlay: RCTDirectEventBlock?
+    var onNativeContentProtectionError: RCTDirectEventBlock?
     var onNativeDimensionChange: RCTDirectEventBlock?
     var onNativeVideoResize: RCTDirectEventBlock?
     
@@ -54,6 +55,7 @@ public class THEOplayerRCTMainEventHandler {
     private var rateChangeListener: EventListener?
     private var waitingListener: EventListener?
     private var canPlayListener: EventListener?
+    private var contentProtectionErrorListener: EventListener?
     private var videoResizeListener: EventListener?
     
     // MARK: player observer
@@ -326,6 +328,25 @@ public class THEOplayerRCTMainEventHandler {
         }
         if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] CanPlay listener attached to THEOplayer") }
         
+        // CONTENT_PROTECTION_ERROR
+        self.contentProtectionErrorListener = player.addEventListener(type: PlayerEventTypes.CONTENT_PROTECTION_ERROR) { [weak self] event in
+            if DEBUG_THEOPLAYER_EVENTS { PrintUtils.printLog(logText: "[NATIVE] Received CONTENT_PROTECTION_ERROR event from THEOplayer") }
+            if let forwardedContentProtectionErrorEvent = self?.onNativeContentProtectionError,
+               let errorObject = event.errorObject {
+                let errorCodeString = String(errorObject.code.rawValue)
+                let errorCodeMessage = errorObject.message
+                forwardedContentProtectionErrorEvent(
+                    [
+                        "error": [
+                            "errorCode": errorCodeString,
+                            "errorMessage": errorCodeMessage
+                        ]
+                    ]
+                )
+            }
+        }
+        if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] ContentProtectionError listener attached to THEOplayer") }
+        
         // RESIZE
         self.videoResizeListener = player.addEventListener(type: PlayerEventTypes.RESIZE) { [weak self, weak player] event in
             if DEBUG_THEOPLAYER_EVENTS { PrintUtils.printLog(logText: "[NATIVE] Received RESIZE event from THEOplayer") }
@@ -486,6 +507,12 @@ public class THEOplayerRCTMainEventHandler {
         self.dimensionChangeObserver?.invalidate()
         self.dimensionChangeObserver = nil
       
+        // CONTENT_PROTECTION_ERROR
+        if let contentProtectionErrorListener = self.contentProtectionErrorListener {
+            player.removeEventListener(type: PlayerEventTypes.CONTENT_PROTECTION_ERROR, listener: contentProtectionErrorListener)
+            if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] ContentProtectionError listener dettached from THEOplayer") }
+        }
+        
         // RESIZE
         if let videoResizeListener = self.videoResizeListener {
           player.removeEventListener(type: PlayerEventTypes.RESIZE, listener: videoResizeListener)

--- a/ios/THEOplayerRCTMainEventHandler.swift
+++ b/ios/THEOplayerRCTMainEventHandler.swift
@@ -55,7 +55,6 @@ public class THEOplayerRCTMainEventHandler {
     private var rateChangeListener: EventListener?
     private var waitingListener: EventListener?
     private var canPlayListener: EventListener?
-    private var contentProtectionErrorListener: EventListener?
     private var videoResizeListener: EventListener?
     
     // MARK: player observer
@@ -328,25 +327,6 @@ public class THEOplayerRCTMainEventHandler {
         }
         if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] CanPlay listener attached to THEOplayer") }
         
-        // CONTENT_PROTECTION_ERROR
-        self.contentProtectionErrorListener = player.addEventListener(type: PlayerEventTypes.CONTENT_PROTECTION_ERROR) { [weak self] event in
-            if DEBUG_THEOPLAYER_EVENTS { PrintUtils.printLog(logText: "[NATIVE] Received CONTENT_PROTECTION_ERROR event from THEOplayer") }
-            if let forwardedContentProtectionErrorEvent = self?.onNativeContentProtectionError,
-               let errorObject = event.errorObject {
-                let errorCodeString = String(errorObject.code.rawValue)
-                let errorCodeMessage = errorObject.message
-                forwardedContentProtectionErrorEvent(
-                    [
-                        "error": [
-                            "errorCode": errorCodeString,
-                            "errorMessage": errorCodeMessage
-                        ]
-                    ]
-                )
-            }
-        }
-        if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] ContentProtectionError listener attached to THEOplayer") }
-        
         // RESIZE
         self.videoResizeListener = player.addEventListener(type: PlayerEventTypes.RESIZE) { [weak self, weak player] event in
             if DEBUG_THEOPLAYER_EVENTS { PrintUtils.printLog(logText: "[NATIVE] Received RESIZE event from THEOplayer") }
@@ -507,12 +487,6 @@ public class THEOplayerRCTMainEventHandler {
         self.dimensionChangeObserver?.invalidate()
         self.dimensionChangeObserver = nil
       
-        // CONTENT_PROTECTION_ERROR
-        if let contentProtectionErrorListener = self.contentProtectionErrorListener {
-            player.removeEventListener(type: PlayerEventTypes.CONTENT_PROTECTION_ERROR, listener: contentProtectionErrorListener)
-            if DEBUG_EVENTHANDLER { PrintUtils.printLog(logText: "[NATIVE] ContentProtectionError listener dettached from THEOplayer") }
-        }
-        
         // RESIZE
         if let videoResizeListener = self.videoResizeListener {
           player.removeEventListener(type: PlayerEventTypes.RESIZE, listener: videoResizeListener)

--- a/ios/THEOplayerRCTView.swift
+++ b/ios/THEOplayerRCTView.swift
@@ -470,6 +470,12 @@ public class THEOplayerRCTView: UIView {
         if DEBUG_VIEW { PrintUtils.printLog(logText: "[NATIVE] nativeCanPlay prop set.") }
     }
     
+    @objc(setOnNativeContentProtectionError:)
+    func setOnNativeContentProtectionError(nativeContentProtectionError: @escaping RCTDirectEventBlock) {
+        self.mainEventHandler.onNativeContentProtectionError = nativeContentProtectionError
+        if DEBUG_VIEW { PrintUtils.printLog(logText: "[NATIVE] nativeContentProtectionError prop set.") }
+    }
+    
     @objc(setOnNativeDimensionChange:)
     func setOnNativeDimensionChange(nativeDimensionChange: @escaping RCTDirectEventBlock) {
         self.mainEventHandler.onNativeDimensionChange = nativeDimensionChange

--- a/src/api/error/ContentProtectionError.ts
+++ b/src/api/error/ContentProtectionError.ts
@@ -1,0 +1,58 @@
+/**
+ * An error related to content protection.
+ *
+ * @category Errors
+ * @category Content Protection
+ * @public
+ */
+export interface ContentProtectionErrorObject {
+  /**
+   * The error code.
+   */
+  readonly errorCode: string;
+
+  /**
+   * The error message.
+   */
+  readonly errorMessage: string;
+
+  /**
+   * The URL that was used in the request.
+   *
+   * @remarks
+   * Only available for certificate or license request errors.
+   */
+  readonly url?: string;
+
+  /**
+   * The status code from the HTTP response.
+   *
+   * @remarks
+   * Only available for certificate or license request errors.
+   */
+  readonly status?: number;
+
+  /**
+   * The status text from the HTTP response.
+   *
+   * @remarks
+   * Only available for certificate or license request errors.
+   */
+  readonly statusText?: string;
+
+  /**
+   * The body contained in the HTTP response.
+   *
+   * @remarks
+   * Only available for certificate or license request errors.
+   */
+  readonly response?: string;
+
+  /**
+   * The internal error code from the CDM.
+   *
+   * @remarks
+   * Only available for internal CDM errors.
+   */
+  readonly systemCode?: number;
+}

--- a/src/api/error/barrel.ts
+++ b/src/api/error/barrel.ts
@@ -1,2 +1,3 @@
 export * from './PlayerError';
 export * from './ChromecastError';
+export * from './ContentProtectionError';

--- a/src/api/event/PlayerEvent.ts
+++ b/src/api/event/PlayerEvent.ts
@@ -1,4 +1,4 @@
-import type { MediaTrack, PlayerError, PlayerEventType, PresentationMode, TextTrack, TypedSource } from 'react-native-theoplayer';
+import type { MediaTrack, PlayerError, PlayerEventType, PresentationMode, TextTrack, TypedSource, ContentProtectionErrorObject } from 'react-native-theoplayer';
 import type { TimeRange } from '../timeranges/TimeRange';
 import type { Event } from './Event';
 
@@ -296,4 +296,19 @@ export interface SeekedEvent extends Event<PlayerEventType.SEEKED> {
    * The player's current time.
    */
   readonly currentTime: number;
+}
+
+/**
+ * Dispatched when an error related to content protection occurs.
+ *
+ * @category Events
+ * @category Player
+ * @category Content Protection
+ * @public
+ */
+export interface ContentProtectionErrorEvent extends Event<PlayerEventType.CONTENT_PROTECTION_ERROR> {
+  /**
+   * An error object containing additional information about the content protection error.
+   */
+  readonly error: ContentProtectionErrorObject;
 }

--- a/src/api/player/PlayerEventMap.ts
+++ b/src/api/player/PlayerEventMap.ts
@@ -1,5 +1,6 @@
 import type { Event } from '../event/Event';
 import type {
+  ContentProtectionErrorEvent,
   CurrentSourceChangeEvent,
   DimensionChangeEvent,
   DurationChangeEvent,
@@ -63,6 +64,7 @@ export enum PlayerEventType {
   DESTROY = 'destroy',
   DIMENSION_CHANGE = 'dimensionchange',
   VIDEO_RESIZE = 'videoresize',
+  CONTENT_PROTECTION_ERROR = 'contentprotectionerror',
 }
 
 /**
@@ -242,4 +244,9 @@ export interface PlayerEventMap {
    * Dispatched when the video size changes.
    */
   [PlayerEventType.VIDEO_RESIZE]: VideoResizeEvent;
+
+  /**
+   * Dispatched when an error related to content protection occurs.
+   */
+  [PlayerEventType.CONTENT_PROTECTION_ERROR]: ContentProtectionErrorEvent;
 }

--- a/src/internal/THEOplayerView.tsx
+++ b/src/internal/THEOplayerView.tsx
@@ -23,6 +23,7 @@ import {
   DefaultAirplayStateChangeEvent,
   DefaultChromecastChangeEvent,
   DefaultChromecastErrorEvent,
+  DefaultContentProtectionErrorEvent,
   DefaultCurrentSourceChangeEvent,
   DefaultDimensionChangeEvent,
   DefaultDurationChangeEvent,
@@ -52,6 +53,7 @@ import type {
 } from './adapter/event/native/NativeTrackEvent';
 import { toMediaTrackType, toMediaTrackTypeEventType, toTextTrackEventType, toTrackListEventType } from './adapter/event/native/NativeTrackEvent';
 import {
+  NativeContentProtectionErrorEvent,
   NativeCurrentSourceChangeEvent,
   NativeDurationChangeEvent,
   NativeErrorEvent,
@@ -116,6 +118,7 @@ interface THEOplayerRCTViewProps {
   onNativeCastEvent: (event: NativeSyntheticEvent<NativeCastEvent>) => void;
   onNativePresentationModeChange: (event: NativeSyntheticEvent<NativePresentationModeChangeEvent>) => void;
   onNativeDeviceOrientationChanged: () => void;
+  onNativeContentProtectionError: (event: NativeSyntheticEvent<NativeContentProtectionErrorEvent>) => void;
   onNativeDimensionChange: (event: NativeSyntheticEvent<NativeDimensionChangeEvent>) => void;
   onNativeVideoResize: (event: NativeSyntheticEvent<NativeVideoResizeEvent>) => void;
 }
@@ -422,6 +425,10 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
     this._facade?.dispatchEvent(new DefaultDimensionChangeEvent(width, height));
   };
 
+  private _onContentProtectionError = (event: NativeSyntheticEvent<NativeContentProtectionErrorEvent>) => {
+    this._facade?.dispatchEvent(new DefaultContentProtectionErrorEvent(event.nativeEvent.error));
+  };
+
   private _onVideoResize = (event: NativeSyntheticEvent<NativeVideoResizeEvent>) => {
     this._facade?.dispatchEvent(new DefaultVideoResizeEvent(event.nativeEvent.videoWidth, event.nativeEvent.videoHeight));
   };
@@ -503,6 +510,7 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
           onNativeCastEvent={this._onCastEvent}
           onNativePresentationModeChange={this._onPresentationModeChange}
           onNativeDeviceOrientationChanged={this._onDeviceOrientationChanged}
+          onNativeContentProtectionError={this._onContentProtectionError}
           onNativeDimensionChange={this._onDimensionChange}
           onNativeVideoResize={this._onVideoResize}
         />

--- a/src/internal/adapter/WebEventForwarder.ts
+++ b/src/internal/adapter/WebEventForwarder.ts
@@ -232,15 +232,16 @@ export class WebEventForwarder {
   };
 
   private readonly onContentProtectionError = (event: NativeContentProtectionErrorEvent) => {
+    const { code, message: errorMessage, url, status, statusText, response, systemCode } = event.errorObject;
     this._facade.dispatchEvent(
       new DefaultContentProtectionErrorEvent({
-        errorCode: event.errorObject.code.toString(),
-        errorMessage: event.errorObject.message,
-        url: event.errorObject.url,
-        status: event.errorObject.status,
-        statusText: event.errorObject.statusText,
-        response: event.errorObject.response,
-        systemCode: event.errorObject.systemCode,
+        errorCode: code.toString(),
+        errorMessage,
+        url,
+        status,
+        statusText,
+        response,
+        systemCode,
       }),
     );
   };

--- a/src/internal/adapter/WebEventForwarder.ts
+++ b/src/internal/adapter/WebEventForwarder.ts
@@ -6,6 +6,7 @@ import type {
   CastStateChangeEvent,
   ChromecastErrorEvent,
   ChromelessPlayer,
+  ContentProtectionErrorEvent as NativeContentProtectionErrorEvent,
   CurrentSourceChangeEvent as NativeCurrentSourceChangeEvent,
   DimensionChangeEvent as NativeDimensionChangeEvent,
   DurationChangeEvent as NativeDurationChangeEvent,
@@ -52,6 +53,7 @@ import {
   DefaultAirplayStateChangeEvent,
   DefaultChromecastChangeEvent,
   DefaultChromecastErrorEvent,
+  DefaultContentProtectionErrorEvent,
   DefaultCurrentSourceChangeEvent,
   DefaultDimensionChangeEvent,
   DefaultDurationChangeEvent,
@@ -112,6 +114,7 @@ export class WebEventForwarder {
     this._player.addEventListener('ratechange', this.onPlaybackRateChange);
     this._player.addEventListener('segmentnotfound', this.onSegmentNotFound);
     this._player.addEventListener('volumechange', this.onVolumeChangeEvent);
+    this._player.addEventListener('contentprotectionerror', this.onContentProtectionError);
     this._player.addEventListener('dimensionchange', this.onDimensionChange);
     this._player.addEventListener('resize', this.onVideoResize);
 
@@ -163,6 +166,7 @@ export class WebEventForwarder {
     this._player.removeEventListener('ratechange', this.onPlaybackRateChange);
     this._player.removeEventListener('segmentnotfound', this.onSegmentNotFound);
     this._player.removeEventListener('volumechange', this.onVolumeChangeEvent);
+    this._player.removeEventListener('contentprotectionerror', this.onContentProtectionError);
     this._player.removeEventListener('dimensionchange', this.onDimensionChange);
     this._player.removeEventListener('resize', this.onVideoResize);
 
@@ -223,6 +227,20 @@ export class WebEventForwarder {
       new DefaultErrorEvent({
         errorCode: event.errorObject.code.toString(),
         errorMessage: event.errorObject.message,
+      }),
+    );
+  };
+
+  private readonly onContentProtectionError = (event: NativeContentProtectionErrorEvent) => {
+    this._facade.dispatchEvent(
+      new DefaultContentProtectionErrorEvent({
+        errorCode: event.errorObject.code.toString(),
+        errorMessage: event.errorObject.message,
+        url: event.errorObject.url,
+        status: event.errorObject.status,
+        statusText: event.errorObject.statusText,
+        response: event.errorObject.response,
+        systemCode: event.errorObject.systemCode,
       }),
     );
   };

--- a/src/internal/adapter/event/PlayerEvents.ts
+++ b/src/internal/adapter/event/PlayerEvents.ts
@@ -10,6 +10,8 @@ import {
   ChromecastChangeEvent,
   ChromecastError,
   ChromecastErrorEvent,
+  ContentProtectionErrorEvent,
+  ContentProtectionErrorObject,
   CurrentSourceChangeEvent,
   DimensionChangeEvent,
   DurationChangeEvent,
@@ -312,5 +314,11 @@ export class DefaultChromecastErrorEvent extends BaseEvent<PlayerEventType.CAST_
   constructor(public error: ChromecastError) {
     super(PlayerEventType.CAST_EVENT);
     this.subType = CastEventType.CHROMECAST_ERROR;
+  }
+}
+
+export class DefaultContentProtectionErrorEvent extends BaseEvent<PlayerEventType.CONTENT_PROTECTION_ERROR> implements ContentProtectionErrorEvent {
+  constructor(public readonly error: ContentProtectionErrorObject) {
+    super(PlayerEventType.CONTENT_PROTECTION_ERROR);
   }
 }

--- a/src/internal/adapter/event/native/NativePlayerEvent.ts
+++ b/src/internal/adapter/event/native/NativePlayerEvent.ts
@@ -1,4 +1,5 @@
 import type {
+  ContentProtectionErrorObject,
   MediaTrack,
   PlayerError,
   PlayerVersion,
@@ -160,6 +161,10 @@ export interface NativeSegmentNotFoundEvent {
    * Number of times the segment was retried.
    */
   readonly retryCount: number;
+}
+
+export interface NativeContentProtectionErrorEvent {
+  error: ContentProtectionErrorObject;
 }
 
 export interface NativePlayerStateEvent {


### PR DESCRIPTION
## Summary

Adds a new `contentprotectionerror` player event forwarded from the native THEOplayer SDKs on Web and Android. iOS bridge wiring is in place but the native listener is deferred until the iOS SDK exposes `PlayerEventTypes.CONTENT_PROTECTION_ERROR` (not available in THEOplayerSDK-core 11.5.0).

**TypeScript API:**
- `PlayerEventType.CONTENT_PROTECTION_ERROR = 'contentprotectionerror'` added to the enum
- `ContentProtectionErrorEvent` interface with an `error: ContentProtectionErrorObject` payload
- `ContentProtectionErrorObject` carries `errorCode`, `errorMessage`, and optional DRM-specific fields: `url`, `status`, `statusText`, `response`, `systemCode`
- `DefaultContentProtectionErrorEvent` implementation class + `NativeContentProtectionErrorEvent` native bridge interface

**Platform forwarding:**
- **Web:** `WebEventForwarder` listens on `'contentprotectionerror'` from the Web SDK, maps `errorObject` fields (code, message, url, status, statusText, response, systemCode) into `DefaultContentProtectionErrorEvent`
- **Android:** `PlayerEventEmitter` registers `PlayerEventTypes.CONTENTPROTECTIONERROR`, forwards `errorObject.code` and `message` via `PayloadBuilder.error()`
- **iOS:** Bridge property (`onNativeContentProtectionError`) registered in `THEOplayerRCTBridge.m`, `THEOplayerRCTView.swift`, and `THEOplayerRCTMainEventHandler.swift`. Native SDK listener deferred — `PlayerEventTypes.CONTENT_PROTECTION_ERROR` does not exist in THEOplayerSDK-core 11.5.0.
- **THEOplayerView.tsx:** `onNativeContentProtectionError` callback wired in the render method

Follows the same pattern as existing error events (`ErrorEvent`, `ChromecastErrorEvent`).

Link to Devin session: https://dolby.devinenterprise.com/sessions/76fe44cf882d4024aa2714622570d537
Requested by: @tvanlaerhoven
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-theoplayer/pull/859" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->