### PR TITLE
iOS ID3 binary data

### DIFF
--- a/ios/THEOplayerRCTTrackMetadataAggregator.swift
+++ b/ios/THEOplayerRCTTrackMetadataAggregator.swift
@@ -116,7 +116,7 @@ class THEOplayerRCTTrackMetadataAggregator {
         entry[PROP_STARTTIME] = THEOplayerRCTTypeUtils.encodeInfNan(textTrackCue.startTime * 1000)
         entry[PROP_ENDTIME] = THEOplayerRCTTypeUtils.encodeInfNan(textTrackCue.endTime * 1000)
         if let content = textTrackCue.content {
-            entry[PROP_CUE_CONTENT] = content
+            entry[PROP_CUE_CONTENT] = THEOplayerRCTTypeUtils.bridgeSafe(content)
         } else if let contentString = textTrackCue.contentString {
             entry[PROP_CUE_CONTENT] = contentString
         }
@@ -150,7 +150,7 @@ class THEOplayerRCTTrackMetadataAggregator {
                         } catch {
                             do {
                                 // try reading as data
-                                attributesEntry[key] = try customAttributes.getBytes(for: key)
+                                attributesEntry[key] = THEOplayerRCTTypeUtils.bridgeSafe(try customAttributes.getBytes(for: key))
                             } catch {
                                 print("Unable to extract customAttribute from DateRange cue. Content is limited to String, Double or Data.")
                             }

--- a/ios/THEOplayerRCTTypeUtils.swift
+++ b/ios/THEOplayerRCTTypeUtils.swift
@@ -17,6 +17,22 @@ class THEOplayerRCTTypeUtils {
         }
         return value
     }
+
+    /// Converts a value into a bridge-safe representation: the RN bridge drops values it cannot
+    /// serialize to JSON (e.g. `Data`, which becomes `null`). Binary payloads are converted to
+    /// number arrays, matching the byte-array shape used by the Android bridge.
+    class func bridgeSafe(_ value: Any) -> Any {
+        switch value {
+        case let data as Data:
+            return data.map { Int($0) }
+        case let dictionary as [String: Any]:
+            return dictionary.mapValues { bridgeSafe($0) }
+        case let array as [Any]:
+            return array.map { bridgeSafe($0) }
+        default:
+            return value
+        }
+    }
     
     class func preloadTypeFromString(_ type: String) -> Preload {
         switch type {

--- a/src/api/track/TextTrack.ts
+++ b/src/api/track/TextTrack.ts
@@ -228,8 +228,11 @@ export function removeTextTrackCue(textTrack?: TextTrack, cue?: TextTrackCue) {
  * @internal
  */
 export function addTextTrackCue(textTrack?: TextTrack, cue?: TextTrackCue) {
-  if (textTrack && textTrack.cues && cue && !hasTextTrackCue(textTrack, cue)) {
-    textTrack.cues.push(cue);
+  if (textTrack && cue) {
+    textTrack.cues ??= [];
+    if (!hasTextTrackCue(textTrack, cue)) {
+      textTrack.cues.push(cue);
+    }
   }
 }
 


### PR DESCRIPTION
OptiView in-band ID3 metadata (PRIV frames over THEOlive/HLS) arrived in React Native apps on iOS
with `data: null` — the payload was only visible through an accidental, lossy UTF-8 `text` fallback,
and would be lost entirely for non-UTF-8 payloads. Auditing the full pipeline surfaced issues at
three layers, fixed in one PR per repo:

- **react-native-theoplayer (iOS)**: this PR, the main issue that Stef was seeing 
- **THEOplayer iOS SDK**: https://bitbucket.org/r8szq0vy/theoplayer-next/pull-requests/7459, more alignment changes rather than fixes
- **react-native-theoplayer-xagget**: https://bitbucket.org/r8szq0vy/react-native-theoplayer-xagget/pull-requests/114, aligning xagget picking up the data
 
End-to-end result after all three land: `metadata.cue` events carry the exact payload bytes as
`data: "<base64>"` + `dataEncoding: "base64"` on web, Android and iOS. Changes:
- iOS: recursively convert `Data` values in cue `content` to number arrays before emitting RCT
  events (`THEOplayerRCTTypeUtils.bridgeSafe`) — the RN bridge otherwise nulls them. Matches the
  byte-array shape the Android bridge already produces.
- Same fix for DateRange cue `customAttributes` byte values, which had the identical silent-`null` bug.

Additionally, addTextTrackCue now creates the cues array when absent. The iOS connector omits cues from the track payload when a track has no cues yet (unlike Android, which sends an empty list), so every subsequent ADD_CUE event was silently dropped and track.cues stayed undefined forever on iOS. Disabled tracks are unaffected as they never receive cue events.