### PR TITLE
fix(web): forward cues that already exist when a text track is added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fixed an issue on Android where destroying the player during a pending `MediaPlaybackService` bind could cause a crash.
 - Fixed an issue where `player.paused` remained `true` between the `play` and `playing` events.
+- Fixed an issue on Web and iOS Safari where cues already present when a text track was added, including daterange cues, did not produce `addcue` player events.
+- Fixed an issue where text and media track event listeners were not actually removed when a track was removed.
 
 ### Changed
 
@@ -33,10 +35,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Upgraded example app to support React Native v0.86.2.
 
-### Fixed
-
-- Fixed an issue on Web and iOS Safari where cues already present when a text track was added, including daterange cues, did not produce `addcue` player events.
-- Fixed an issue where text and media track event listeners were not actually removed when a track was removed.
 ## [11.5.0]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Upgraded example app to support React Native v0.86.2.
 
+### Fixed
+
+- Fixed an issue on Web and iOS Safari where cues already present when a text track was added, including daterange cues, did not produce `addcue` player events.
+- Fixed an issue where text and media track event listeners were not actually removed when a track was removed.
 ## [11.5.0]
 
 ### Fixed

--- a/src/internal/adapter/WebEventForwarder.ts
+++ b/src/internal/adapter/WebEventForwarder.ts
@@ -519,10 +519,9 @@ export class WebEventForwarder {
 
   private readonly onEnterTextTrackCue = (track: NativeTextTrack) => (event: NativeTextTrackEnterCueEvent) => {
     const { cue } = event;
-    if (!cue) {
-      return;
+    if (cue) {
+      this._facade.dispatchEvent(new DefaultTextTrackEvent(TextTrackEventType.ENTER_CUE, track.uid, fromNativeCue(cue)));
     }
-    this._facade.dispatchEvent(new DefaultTextTrackEvent(TextTrackEventType.ENTER_CUE, track.uid, fromNativeCue(cue)));
   };
 
   private readonly onExitTextTrackCue = (track: NativeTextTrack) => (event: NativeTextTrackExitCueEvent) => {

--- a/src/internal/adapter/WebEventForwarder.ts
+++ b/src/internal/adapter/WebEventForwarder.ts
@@ -86,6 +86,18 @@ import { fromNativeCue, fromNativeMediaTrack, fromNativeTextTrack } from './web/
 export class WebEventForwarder {
   private readonly _player: ChromelessPlayer;
   private readonly _facade: THEOplayerWebAdapter;
+  private readonly _textTrackListeners = new Map<
+    number,
+    {
+      track: NativeTextTrack;
+      addcue: (event: NativeTextTrackAddCueEvent) => void;
+      removecue: (event: NativeTextTrackRemoveCueEvent) => void;
+      entercue: (event: NativeTextTrackEnterCueEvent) => void;
+      exitcue: (event: NativeTextTrackExitCueEvent) => void;
+    }
+  >();
+  private readonly _forwardedTextTrackCues = new Map<number, Set<number>>();
+  private readonly _mediaTrackListeners = new Map<number, { track: NativeMediaTrack; listener: () => void }>();
 
   constructor(player: ChromelessPlayer, facade: THEOplayerWebAdapter) {
     this._player = player;
@@ -193,6 +205,20 @@ export class WebEventForwarder {
     this._player.ads?.removeEventListener(FORWARDED_ADBREAK_EVENTS, this.onAdBreakEvent);
     this._player.theoads?.removeEventListener(FORWARDED_THEOADS_EVENTS, this.onTheoAdsEvent);
     this._player.theoLive?.removeEventListener(FORWARDED_THEOLIVE_EVENTS, this.onTheoLiveEvent);
+
+    for (const listeners of this._textTrackListeners.values()) {
+      listeners.track.removeEventListener('addcue', listeners.addcue);
+      listeners.track.removeEventListener('removecue', listeners.removecue);
+      listeners.track.removeEventListener('entercue', listeners.entercue);
+      listeners.track.removeEventListener('exitcue', listeners.exitcue);
+    }
+    this._textTrackListeners.clear();
+    this._forwardedTextTrackCues.clear();
+
+    for (const listeners of this._mediaTrackListeners.values()) {
+      listeners.track.removeEventListener('activequalitychanged', listeners.listener);
+    }
+    this._mediaTrackListeners.clear();
   }
 
   private readonly onSourceChange = () => {
@@ -326,19 +352,38 @@ export class WebEventForwarder {
     if (track.kind === TextTrackKind.metadata) {
       track.mode = TextTrackMode.hidden;
     }
-    track.addEventListener('addcue', this.onAddTextTrackCue(track));
-    track.addEventListener('removecue', this.onRemoveTextTrackCue(track));
-    track.addEventListener('entercue', this.onEnterTextTrackCue(track));
-    track.addEventListener('exitcue', this.onExitTextTrackCue(track));
+    const listeners = {
+      track,
+      addcue: this.onAddTextTrackCue(track),
+      removecue: this.onRemoveTextTrackCue(track),
+      entercue: this.onEnterTextTrackCue(track),
+      exitcue: this.onExitTextTrackCue(track),
+    };
+    this._textTrackListeners.set(track.uid, listeners);
+    const replayedCues = new Set<number>();
+    track.cues?.forEach((cue) => replayedCues.add(cue.uid));
+    this._forwardedTextTrackCues.set(track.uid, replayedCues);
+    track.addEventListener('addcue', listeners.addcue);
+    track.addEventListener('removecue', listeners.removecue);
+    track.addEventListener('entercue', listeners.entercue);
+    track.addEventListener('exitcue', listeners.exitcue);
     this._facade.dispatchEvent(new DefaultTextTrackListEvent(TrackListEventType.ADD_TRACK, fromNativeTextTrack(track)));
+    track.cues?.forEach((cue) => {
+      this._facade.dispatchEvent(new DefaultTextTrackEvent(TextTrackEventType.ADD_CUE, track.uid, fromNativeCue(cue)));
+    });
   };
 
   private readonly onRemoveTextTrack = (event: RemoveTrackEvent) => {
     const track = event.track as NativeTextTrack;
-    track.removeEventListener('addcue', this.onAddTextTrackCue(track));
-    track.removeEventListener('removecue', this.onRemoveTextTrackCue(track));
-    track.removeEventListener('entercue', this.onEnterTextTrackCue(track));
-    track.removeEventListener('exitcue', this.onExitTextTrackCue(track));
+    const listeners = this._textTrackListeners.get(track.uid);
+    if (listeners) {
+      track.removeEventListener('addcue', listeners.addcue);
+      track.removeEventListener('removecue', listeners.removecue);
+      track.removeEventListener('entercue', listeners.entercue);
+      track.removeEventListener('exitcue', listeners.exitcue);
+      this._textTrackListeners.delete(track.uid);
+    }
+    this._forwardedTextTrackCues.delete(track.uid);
     this._facade.dispatchEvent(new DefaultTextTrackListEvent(TrackListEventType.REMOVE_TRACK, fromNativeTextTrack(track)));
   };
 
@@ -356,7 +401,9 @@ export class WebEventForwarder {
 
   private readonly onAddMediaTrack = (event: AddTrackEvent, trackType: MediaTrackType) => {
     const track = event.track as NativeMediaTrack;
-    track.addEventListener('activequalitychanged', this.onActiveQualityChanged(trackType, track));
+    const listener = this.onActiveQualityChanged(trackType, track);
+    this._mediaTrackListeners.set(track.uid, { track, listener });
+    track.addEventListener('activequalitychanged', listener);
     this._facade.dispatchEvent(new DefaultMediaTrackListEvent(TrackListEventType.ADD_TRACK, trackType, track as MediaTrack));
   };
 
@@ -370,7 +417,11 @@ export class WebEventForwarder {
 
   private readonly onRemoveMediaTrack = (event: RemoveTrackEvent, trackType: MediaTrackType) => {
     const track = event.track as NativeMediaTrack;
-    track.removeEventListener('activequalitychanged', this.onActiveQualityChanged(trackType, track));
+    const listeners = this._mediaTrackListeners.get(track.uid);
+    if (listeners) {
+      track.removeEventListener('activequalitychanged', listeners.listener);
+      this._mediaTrackListeners.delete(track.uid);
+    }
     this._facade.dispatchEvent(new DefaultMediaTrackListEvent(TrackListEventType.REMOVE_TRACK, trackType, track as MediaTrack));
   };
 
@@ -447,6 +498,10 @@ export class WebEventForwarder {
   private readonly onAddTextTrackCue = (track: NativeTextTrack) => (event: NativeTextTrackAddCueEvent) => {
     const { cue } = event;
     if (cue) {
+      const replayedCues = this._forwardedTextTrackCues.get(track.uid);
+      if (replayedCues?.has(cue.uid)) {
+        return;
+      }
       this._facade.dispatchEvent(new DefaultTextTrackEvent(TextTrackEventType.ADD_CUE, track.uid, fromNativeCue(cue)));
     }
   };
@@ -454,15 +509,20 @@ export class WebEventForwarder {
   private readonly onRemoveTextTrackCue = (track: NativeTextTrack) => (event: NativeTextTrackRemoveCueEvent) => {
     const { cue } = event;
     if (cue) {
+      const replayedCues = this._forwardedTextTrackCues.get(track.uid);
+      if (replayedCues) {
+        replayedCues.delete(cue.uid);
+      }
       this._facade.dispatchEvent(new DefaultTextTrackEvent(TextTrackEventType.REMOVE_CUE, track.uid, fromNativeCue(cue)));
     }
   };
 
   private readonly onEnterTextTrackCue = (track: NativeTextTrack) => (event: NativeTextTrackEnterCueEvent) => {
     const { cue } = event;
-    if (cue) {
-      this._facade.dispatchEvent(new DefaultTextTrackEvent(TextTrackEventType.ENTER_CUE, track.uid, fromNativeCue(cue)));
+    if (!cue) {
+      return;
     }
+    this._facade.dispatchEvent(new DefaultTextTrackEvent(TextTrackEventType.ENTER_CUE, track.uid, fromNativeCue(cue)));
   };
 
   private readonly onExitTextTrackCue = (track: NativeTextTrack) => (event: NativeTextTrackExitCueEvent) => {


### PR DESCRIPTION
## Summary

`WebEventForwarder.onAddTextTrack` attached the track-level `addcue` listener only when `addtrack` fired, so any cue already present on the track at that moment produced no player-level `TEXT_TRACK`/`addcue` event. On iOS Safari the web SDK populates daterange cues before firing `addtrack`, so consumers listening on `PlayerEventType.TEXT_TRACK` never received them (the cues were only visible via `event.track.cues` on the `TEXT_TRACK_LIST` event).

Fix: after dispatching `ADD_TRACK`, replay the cues already on the track as `ADD_CUE` player events. Their uids are remembered so a native `addcue` arriving later for one of those same cues is not forwarded twice; a uid is dropped from that set on `removecue`, so a genuine remove/re-add still forwards. The set only ever holds cues that existed at `addtrack` time — cues arriving afterwards are forwarded with no bookkeeping.

```diff
   dispatchEvent(ADD_TRACK, fromNativeTextTrack(track));
+  track.cues?.forEach((cue) => dispatchEvent(ADD_CUE, track.uid, fromNativeCue(cue)));
```

Second, unrelated-but-adjacent fix: track listener removal never worked. `onRemoveTextTrack` / `onRemoveMediaTrack` called `removeEventListener` with a freshly created closure (`this.onAddTextTrackCue(track)`), a different function identity than the one registered — so cue and `activequalitychanged` listeners stayed attached for the life of the player, leaking and dispatching events for removed tracks. The listeners are now kept per track uid and the exact registered reference is removed; `removeEventListeners()` also detaches tracks that were never explicitly removed.

Note the same attach-on-`ADD_TRACK` pattern exists in the iOS (`THEOplayerRCTTextTrackEventHandler`) and Android (`PlayerEventEmitter`) handlers; those are left alone since the native SDKs fire `addcue` after `addtrack`.

## Verification

No JS test framework exists in this repo, so this was verified with a standalone script driving the compiled forwarder against a fake player/track emitter, covering: cues present at `addtrack` are forwarded after `ADD_TRACK`; a duplicate native `addcue` for a replayed cue is suppressed; remove-then-re-add of the same cue is forwarded again; no cue events after `removetrack`. `npm run lint`, `npm run prettier` and `tsc -p tsconfig.build.json` pass.


Link to Devin session: https://dolby.devinenterprise.com/sessions/fc9bf7b3e83e4f2bafb75a3d70edcb3c
Requested by: @tvanlaerhoven
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-theoplayer/pull/891" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->