### PR TITLE
OPTI-3910: Android crash when destroying player during pending MediaPlaybackService bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.1.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed an issue on Android where destroying the player during a pending `MediaPlaybackService` bind could cause a crash.
+
 ## [11.6.0]
 
 ### Added

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -51,6 +51,7 @@ class ReactTHEOplayerContext private constructor(
   private val mainHandler = Handler(Looper.getMainLooper())
   private var isBound = AtomicBoolean()
   private var binder: MediaPlaybackService.MediaPlaybackBinder? = null
+  private var isDestroyed = false
 
   private var audioBecomingNoisyManager = AudioBecomingNoisyManager(reactContext) {
     // Audio is about to become 'noisy' due to a change in audio outputs: pause the player
@@ -135,6 +136,17 @@ class ReactTHEOplayerContext private constructor(
 
   private val connection = object : ServiceConnection {
     override fun onServiceConnected(className: ComponentName, service: IBinder) {
+      // The context may have been destroyed while the bind was still pending.
+      // Do not attach the destroyed player/context to the service.
+      if (isDestroyed) {
+        try {
+          reactContext.unbindService(this)
+        } catch (e: IllegalArgumentException) {
+          // Connection was not registered or already unbound; ignore.
+        }
+        return
+      }
+
       binder = service as MediaPlaybackService.MediaPlaybackBinder
 
       // Get media session connector from service
@@ -202,11 +214,13 @@ class ReactTHEOplayerContext private constructor(
   }
 
   private fun unbindMediaPlaybackService() {
-    // This client is done interacting with the service: unbind.
-    // When there are no clients bound to the service, the system destroys the service.
-    if (binder?.isBinderAlive == true) {
-      if (isBound.getAndSet(false)) {
+    // Always unbind when isBound, regardless of whether the binder is alive yet: a pending
+    // bind must still be cancelled so a late callback cannot resurrect this.
+    if (isBound.getAndSet(false)) {
+      try {
         reactContext.unbindService(connection)
+      } catch (e: IllegalArgumentException) {
+        // Service was not registered or already unbound; ignore.
       }
     }
     binder = null
@@ -472,6 +486,7 @@ class ReactTHEOplayerContext private constructor(
   }
 
   fun destroy() {
+    isDestroyed = true
     removeListeners()
 
     if (BuildConfig.USE_PLAYBACK_SERVICE) {
@@ -482,6 +497,7 @@ class ReactTHEOplayerContext private constructor(
       unbindMediaPlaybackService()
     }
     audioFocusManager?.abandonAudioFocus()
+    mediaSessionConnector?.player = null
     mediaControlProxy.destroy()
     mediaSessionConnector?.destroy()
     playerView.onDestroy()

--- a/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
+++ b/android/src/main/java/com/theoplayer/ReactTHEOplayerContext.kt
@@ -489,6 +489,10 @@ class ReactTHEOplayerContext private constructor(
     isDestroyed = true
     removeListeners()
 
+    // The media session can be shared with other player contexts through the playback service.
+    // Determine ownership before unbinding, as that clears the binder needed to check it.
+    val ownedMediaSession = ownsMediaSession()
+
     if (BuildConfig.USE_PLAYBACK_SERVICE) {
       // Remove service from foreground
       binder?.stopForegroundService()
@@ -497,9 +501,13 @@ class ReactTHEOplayerContext private constructor(
       unbindMediaPlaybackService()
     }
     audioFocusManager?.abandonAudioFocus()
-    mediaSessionConnector?.player = null
     mediaControlProxy.destroy()
-    mediaSessionConnector?.destroy()
+    if (ownedMediaSession) {
+      // Only tear down the session when another player did not take it over: a queued callback
+      // must never reach this destroyed player, but a newly-activated player must keep working.
+      mediaSessionConnector?.player = null
+      mediaSessionConnector?.destroy()
+    }
     playerView.onDestroy()
   }
 }


### PR DESCRIPTION
This fixes a crash that happens when the player is destroyed before the `MediaPlaybackService` bind completes. A command sent the leftover notification threw `IllegalStateException: Must not be destroyed` from the underlying SDK.

The fix always unbinds on destroy (regardless of binder state), guards `onServiceConnected` with an `isDestroyed` check, and clears the player reference so queued callbacks cannot reach a destroyed player.