### PR TITLE
fix(e2e): give component lookups room for cold-start player creation

### DIFF
--- a/e2e/src/TestableApp.tsx
+++ b/e2e/src/TestableApp.tsx
@@ -8,6 +8,8 @@ import { PlayerConfiguration, PlayerEventType, THEOplayer } from 'react-native-t
 import { Log } from './utils/Log';
 
 const testHookStore = new TestHookStore();
+// Debug simulators need extra time for cold-start native player creation.
+const TESTER_WAIT_TIME = 30_000;
 
 const playerConfig: PlayerConfiguration = {
   // On web, THEOplayer needs to know where the transmux workers were copied to.
@@ -58,7 +60,7 @@ class App extends Component {
 
   render() {
     return (
-      <Tester specs={Specs} store={testHookStore}>
+      <Tester specs={Specs} store={testHookStore} waitTime={TESTER_WAIT_TIME}>
         <SafeAreaView style={[StyleSheet.absoluteFill, { backgroundColor: '#000000' }]}>
           <View style={PLAYER_CONTAINER_STYLE}>
             <TestableTHEOplayerView config={playerConfig} onPlayerReady={this.onPlayerReady} onPlayerDestroy={this.onPlayerDestroy} />


### PR DESCRIPTION
## Summary

The e2e `<Tester>` never set `waitTime`, so `spec.findComponent('Scene.player')` — every spec's
first step, via `preparePlayerWithSource()` — gave up after cavynext's default **2000 ms**:

```tsx
<Tester specs={Specs} store={testHookStore} waitTime={30_000}>
```

The player is only registered in the hook store from `onPlayerReady`, and on an iOS/tvOS
simulator the *first* `onPlayerReady` after app launch takes **3–9 s** (measured across recent
runs of #893: 3.2 s, 3.5 s, 4.5 s, 6.0 s, 8.9 s; Android is 0.3 s because its e2e app is built
`--mode release`, while iOS/tvOS run Debug off Metro). So the first player-dependent test(s) of
a run raced player creation and failed with

```
Could not find component with identifier Scene.player.
Hooked identifiers: Scene.THEOplayerView.
```

and passed on retry — the flakiness that is "mostly iOS, sometimes Android". `waitTime` is only
an upper bound on the polling loop (100 ms interval), so a generous value costs nothing once the
player is registered; the run with 8.9 s of cold start is comfortably inside 30 s.

Two things this does *not* fix, both in cavynext itself and patched separately:

- `WebSocketReporter.sendData()` drops every event while the socket is still `CONNECTING`, so
  the `❌ … Caught error: …` line of exactly these early failures never reaches the log — which
  is why the run summary reported failures while the log showed only green ticks. Symptom
  visible in every job: `cavynext test suite started at …` is missing from all 21 logs
  inspected, and printed results are always fewer than `N examples` (even green Android/web runs
  print 27 of 28).
- The remaining iOS/tvOS flakes are unrelated to the race above: `Player error … errorCode
  5003` on *"Set mp4 … dispatches a seeked event after seeking"*, and `Expected true to be
  falsy` on *"… paused, play and playing events after pausing & resuming"*.


Link to Devin session: https://dolby.devinenterprise.com/sessions/9cbd83149afa4521a7b0cdfbb9b09118
Requested by: @tvanlaerhoven
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-theoplayer/pull/896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->