### PR TITLE
Remove RctRootContentView which is removed in RN 0.87.0

### DIFF
--- a/ios/Theoplayer-Bridging-Header.h
+++ b/ios/Theoplayer-Bridging-Header.h
@@ -6,4 +6,3 @@
 #import <React/RCTUIManager.h>
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
-#import <React/RCTRootContentView.h>


### PR DESCRIPTION
RctRootContentView.h is removed with RN 0.87.0, see https://github.com/react/react-native/commit/23ce90bd3bdf
