### PR TITLE
feat: add testID to THEOplayerView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Added the `Metrics` API, accessible through `player.metrics`, with `currentBandwidthEstimate` returning the player's estimated available bandwidth in bits per second. On iOS/tvOS this value is only reported for THEOlive/HESP streams.
 - Added `THEOplayer.manageContentMatching` to let the player match the display mode (frame rate and dynamic range) of the TV to the content before playback starts on tvOS.
+- Added a `testID` property on `THEOplayerView` to allow locating the player view from UI automation tools.
 
 ### Fixed
 

--- a/src/api/THEOplayerView.ts
+++ b/src/api/THEOplayerView.ts
@@ -24,6 +24,11 @@ export interface THEOplayerViewProps {
   posterStyle?: StyleProp<ImageStyle> | undefined;
 
   /**
+   * The testID applied to the player view, used to locate it from UI automation tools.
+   */
+  testID?: string;
+
+  /**
    * Callback for when the internal THEOplayer is ready.
    */
   onPlayerReady?: (player: THEOplayer) => void;

--- a/src/internal/THEOplayerView.tsx
+++ b/src/internal/THEOplayerView.tsx
@@ -475,11 +475,11 @@ export class THEOplayerView extends PureComponent<React.PropsWithChildren<THEOpl
   }
 
   public render(): React.JSX.Element {
-    const { config, style, posterStyle, children } = this.props;
+    const { config, style, posterStyle, testID, children } = this.props;
     const { posterActive, poster } = this.state;
 
     return (
-      <View style={[styles.base, style, this.styleOverride()]}>
+      <View testID={testID} style={[styles.base, style, this.styleOverride()]}>
         <THEOplayerRCTView
           ref={this._root}
           style={StyleSheet.absoluteFill}

--- a/src/internal/THEOplayerView.web.tsx
+++ b/src/internal/THEOplayerView.web.tsx
@@ -5,7 +5,7 @@ import { THEOplayerWebAdapter } from './adapter/THEOplayerWebAdapter';
 import { useIsAttached } from './hooks/useIsAttached';
 
 export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProps>) {
-  const { config, children, onPlayerReady, onPlayerDestroy } = props;
+  const { config, children, onPlayerReady, onPlayerDestroy, testID } = props;
   const player = useRef<ChromelessPlayer | null>(null);
   const adapter = useRef<THEOplayerWebAdapter | null>(null);
   const container = useRef<HTMLDivElement | null>(null);
@@ -59,7 +59,7 @@ export function THEOplayerView(props: React.PropsWithChildren<THEOplayerViewProp
     // Note: `display: contents` causes an element's children to appear as if they were direct children of the element's parent,
     // ignoring the element itself.
     // It's necessary to make sure we do not interfere with the IMA container
-    <div id={'theoplayer-root-container'} style={{ display: CSS.supports('display', 'contents') ? 'contents' : 'flex' }}>
+    <div id={'theoplayer-root-container'} data-testid={testID} style={{ display: CSS.supports('display', 'contents') ? 'contents' : 'flex' }}>
       {!CSS.supports('aspect-ratio', '16/9') ? (
         // Handle aspect-ratio 16/9 with padding-top: 56.25% to support older versions.
         // {@link https://www.w3schools.com/howto/howto_css_aspect_ratio.asp}


### PR DESCRIPTION
## Summary

Closes #814.

`THEOplayerView` swallowed `testID`, so UI-automation drivers could not locate the player view and users had to patch `node_modules`. The prop is now part of the public API and forwarded on every platform:

```diff
 // src/internal/THEOplayerView.tsx (native)
-<View style={[styles.base, style, this.styleOverride()]}>
+<View testID={testID} style={[styles.base, style, this.styleOverride()]}>

 // src/internal/THEOplayerView.web.tsx
-<div id={'theoplayer-root-container'} style={...}>
+<div id={'theoplayer-root-container'} data-testid={testID} style={...}>
```

Native matches the patch in the issue; on web `data-testid` is the attribute react-native-web maps `testID` to. Only the outer wrapper carries the identifier — it is the stable element across fullscreen/PiP reparenting, and a second identifier on the inner player view would make automation queries ambiguous.

Note the issue title mentions the UI layer — the player controls live in `@theoplayer/react-native-ui`, so testIDs on individual control components would be a separate change in that repo.


Link to Devin session: https://dolby.devinenterprise.com/sessions/ae7eba3018ba4e4484ef5553928758ab
Open in Devin Desktop: https://dolby.devinenterprise.com/desktop/session/ae7eba3018ba4e4484ef5553928758ab?variant=devin
Requested by: @tvanlaerhoven
<!-- devin-review-badge-begin -->

---

<a href="https://dolby.devinenterprise.com/review/theoplayer/react-native-theoplayer/pull/903" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->